### PR TITLE
Fix initialize on create for embedded resources

### DIFF
--- a/src/relayer/Resource.js
+++ b/src/relayer/Resource.js
@@ -135,6 +135,7 @@ export default class Resource extends DataWrapper {
       if (relationshipDescription.initializeOnCreate) {
         var relationship = relationshipDescription.initializer.initialize();
         this.relationships[relationshipName] = relationship;
+        this.pathBuild(relationshipDescription.dataPath, relationship.response);
       }
     });
   }

--- a/test/Resource.js
+++ b/test/Resource.js
@@ -70,9 +70,12 @@ describe("relationships initialization", function() {
     relationshipDescription = {
       initializer: {
         initialize() {
-          return "awesome"
+          return {
+            response: "awesome"
+          }
         }
-      }
+      },
+      dataPath: "$.data.cool_relationship"
     }
 
     ResourceClass.relationships["coolRelationship"] = relationshipDescription;
@@ -87,7 +90,14 @@ describe("relationships initialization", function() {
 
     it("should call the initializer and save the relationship", function() {
       expect(initializationSpy).toHaveBeenCalled();
-      expect(resource.relationships).toEqual({coolRelationship: "awesome"});
+      expect(resource.relationships).toEqual({coolRelationship: {
+        response: "awesome"
+        }
+      });
+    });
+
+    it("should build the key in the root resource", function() {
+      expect(resource.response["data"]["cool_relationship"]).toEqual("awesome");
     });
   });
 


### PR DESCRIPTION
When a relationship is built with a newly created (non-persisted) resource, it was not properly being saved into the root resource json if the root resource is saved, because the data key was never built. This fixes that.
