### PR TITLE
Fix create template link

### DIFF
--- a/src/relayer/ResourceBuilder.js
+++ b/src/relayer/ResourceBuilder.js
@@ -38,7 +38,8 @@ export default class ResourceBuilder {
       }
       resource.templatedUrl.addDataPathLink(resource, "$.links.self");
       if (this.relationshipDescription.canCreate) {
-        var createResourceTransformer = this.createResourceTransformerFactory(this.relationshipDescription.createRelationshipDescription);
+        var createUriTemplate = uriTemplate || resource.pathGet("$.links.template");
+        var createResourceTransformer = this.createResourceTransformerFactory(this.relationshipDescription.createRelationshipDescription, createUriTemplate);
       } else {
         var createResourceTransformer = this.throwErrorTransformerFactory();
       }

--- a/src/relayer/relationshipDescriptions/ListRelationshipDescription.js
+++ b/src/relayer/relationshipDescriptions/ListRelationshipDescription.js
@@ -132,7 +132,7 @@ export default class ListRelationshipDescription extends RelationshipDescription
       templatedUrl.addDataPathLink(parent, this.linksPath);
       primaryResourceTransformer = this.listResourceTransformer();
       if (this.canCreate) {
-        createTransformer = this.createResourceTransformerFactory(this.createRelationshipDescription);
+        createTransformer = this.createResourceTransformerFactory(this.createRelationshipDescription, parent.pathGet(this._linkTemplatePath));
       }
     }
 

--- a/src/relayer/transformers/CreateResourceTransformer.js
+++ b/src/relayer/transformers/CreateResourceTransformer.js
@@ -4,10 +4,17 @@ import {SimpleFactory} from "../SimpleFactoryInjector.js"
 @SimpleFactory('CreateResourceTransformerFactory', [])
 export default class CreateResourceTransformer extends PrimaryResourceTransformer {
 
+  constructor(relationshipDescription, uriTemplate) {
+    super(relationshipDescription);
+    this.uriTemplate = uriTemplate;
+  }
+
   transformResponse(endpoint, response) {
     return response.then(
       (resolvedResponse) => {
-        var resource = this.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, this.relationshipDescription).map();
+        var resourceMapper = this.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, this.relationshipDescription);
+        resourceMapper.uriTemplate = this.uriTemplate;
+        var resource = resourceMapper.map();
         resource.templatedUrl.etag = resolvedResponse.etag;
         return resource;
       }

--- a/test/ResourceBuilder.js
+++ b/test/ResourceBuilder.js
@@ -187,7 +187,7 @@ describe("ResourceBuilder", function() {
     });
 
     it("should setup the transformers", function() {
-      expect(createResourceTransformerFactory).toHaveBeenCalledWith(createRelationshipDescription);
+      expect(createResourceTransformerFactory).toHaveBeenCalledWith(createRelationshipDescription, "/cheese/{type}");
     });
 
     it("should setup the endpoint properly", function() {

--- a/test/integration/EmbeddedListCreateTest.js
+++ b/test/integration/EmbeddedListCreateTest.js
@@ -122,5 +122,9 @@ describe("Embedded List Create test", function() {
     it("should resolve the book", function() {
       expect(book.title).toEqual("Hamlet");
     });
+
+    it("should resolve short link", function() {
+      expect(book.shortLink).toEqual("1");
+    })
   });
 });

--- a/test/integration/PageTest.js
+++ b/test/integration/PageTest.js
@@ -375,5 +375,8 @@ describe("Page test", function() {
       expect(page.metadata.pageStyles).toEqual('p { font-weight: bold; }');
     });
 
+    it("should resolve shortlink", function() {
+      expect(page.shortLink).toEqual("awesome")
+    })
   });
 });

--- a/test/relationshipDescriptions/ListRelationshipDescription.js
+++ b/test/relationshipDescriptions/ListRelationshipDescription.js
@@ -56,8 +56,8 @@ describe("ListRelationshipDescription", function() {
       });
 
     createResourceTransformerFactory = jasmine.createSpy("primaryResourceTransformerFactory").and.callFake(
-      function(relationship) {
-        return { relationship }
+      function(relationship, uriTemplate) {
+        return { relationship , uriTemplate }
       });
 
     embeddedRelationshipTransformerFactory = jasmine.createSpy("embeddedRelationshipTransformerFactory").and.callFake(
@@ -356,7 +356,8 @@ describe("ListRelationshipDescription", function() {
               mapperFactory: singleResourceMapperFactory,
               serializerFactory: singleResourceSerializerFactory,
               ResourceClass: ResourceClass
-            }
+            },
+            uriTemplate: "/awesomes/{id}"
           });
         expect(linkedEndpoint.new()).toEqual(new ResourceClass());
       });


### PR DESCRIPTION
When doing a create to a list endpoint, the returned created resource did not have its uriTemplate setup properly so you can extract a shortlink/uriParams. This fixes that.
