### PR TITLE
Temporary link option

### DIFF
--- a/dist/cjs/relayer/TemporaryTemplatedUrl.js
+++ b/dist/cjs/relayer/TemporaryTemplatedUrl.js
@@ -1,0 +1,47 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+var _TemplatedUrlJs = require("./TemplatedUrl.js");
+
+var TemporaryTemplatedUrl = (function (_TemplatedUrl) {
+  function TemporaryTemplatedUrl(uriTemplate) {
+    _classCallCheck(this, TemporaryTemplatedUrl);
+
+    _get(Object.getPrototypeOf(TemporaryTemplatedUrl.prototype), "constructor", this).call(this, uriTemplate);
+    var url = this._uriTemplate.fill(function (varName) {
+      return "relayer-" + TemporaryTemplatedUrl.index;
+    });
+    TemporaryTemplatedUrl.index += 1;
+    this._setUrl(url);
+  }
+
+  _inherits(TemporaryTemplatedUrl, _TemplatedUrl);
+
+  _createClass(TemporaryTemplatedUrl, null, [{
+    key: "index",
+    get: function () {
+      this._index = this._index || 1;
+      return this._index;
+    },
+    set: function (index) {
+      this._index = index;
+      return this._index;
+    }
+  }]);
+
+  return TemporaryTemplatedUrl;
+})(_TemplatedUrlJs.TemplatedUrl);
+
+exports["default"] = TemporaryTemplatedUrl;
+module.exports = exports["default"];

--- a/dist/cjs/relayer/mappers/ListResourceMapper.js
+++ b/dist/cjs/relayer/mappers/ListResourceMapper.js
@@ -6,7 +6,7 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-var _get = function get(_x2, _x3, _x4) { var _again = true; _function: while (_again) { var object = _x2, property = _x3, receiver = _x4; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x2 = parent; _x3 = property; _x4 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+var _get = function get(_x3, _x4, _x5) { var _again = true; _function: while (_again) { var object = _x3, property = _x4, receiver = _x5; desc = parent = getter = undefined; _again = false; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x3 = parent; _x4 = property; _x5 = receiver; _again = true; continue _function; } } else if ("value" in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 
@@ -19,6 +19,10 @@ var _ResourceMapperJs = require("./ResourceMapper.js");
 var _ResourceMapperJs2 = _interopRequireDefault(_ResourceMapperJs);
 
 var _TemplatedUrlJs = require("../TemplatedUrl.js");
+
+var _TemporaryTemplatedUrlJs = require("../TemporaryTemplatedUrl.js");
+
+var _TemporaryTemplatedUrlJs2 = _interopRequireDefault(_TemporaryTemplatedUrlJs);
 
 var _ResourceBuilderJs = require("../ResourceBuilder.js");
 
@@ -39,12 +43,13 @@ var _ManyResourceMapperJs2 = _interopRequireDefault(_ManyResourceMapperJs);
 var _injectorJs = require("../injector.js");
 
 var ListResourceMapper = (function (_ResourceMapper) {
-  function ListResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, manyResourceMapperFactory, transport, response, relationshipDescription, endpoint) {
-    var useErrors = arguments[9] === undefined ? false : arguments[9];
+  function ListResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, manyResourceMapperFactory, temporaryTemplatedUrlFactory, transport, response, relationshipDescription, endpoint) {
+    var useErrors = arguments[10] === undefined ? false : arguments[10];
 
     _classCallCheck(this, ListResourceMapper);
 
     _get(Object.getPrototypeOf(ListResourceMapper.prototype), "constructor", this).call(this, templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, transport, response, relationshipDescription, endpoint, useErrors);
+    this.temporaryTemplatedUrlFactory = temporaryTemplatedUrlFactory;
     this.manyResourceMapperFactory = manyResourceMapperFactory;
   }
 
@@ -70,7 +75,8 @@ var ListResourceMapper = (function (_ResourceMapper) {
 
       this.resource = this.mapped;
       var manyResourceMapper = this.manyResourceMapperFactory(this.transport, this.resource.pathGet("$.data"), this.relationshipDescription);
-      manyResourceMapper.uriTemplate = this.resource.pathGet("$.links.template");
+      var uriTemplate = this.resource.pathGet("$.links.template");
+      manyResourceMapper.uriTemplate = uriTemplate;
       this.mapped = manyResourceMapper.map();
       this.mapped.resource = this.resource;
       ["url", "uriTemplate", "uriParams"].forEach(function (func) {
@@ -122,8 +128,15 @@ var ListResourceMapper = (function (_ResourceMapper) {
         });
       };
       var ItemResourceClass = this.ItemResourceClass;
+      var temporaryTemplatedUrlFactory = this.temporaryTemplatedUrlFactory;
       this.mapped["new"] = function () {
-        return new ItemResourceClass();
+        var withUrl = arguments[0] === undefined ? false : arguments[0];
+
+        var item = new ItemResourceClass();
+        if (withUrl) {
+          item.templatedUrl = temporaryTemplatedUrlFactory(uriTemplate);
+        }
+        return item;
       };
     }
   }]);
@@ -133,5 +146,5 @@ var ListResourceMapper = (function (_ResourceMapper) {
 
 exports["default"] = ListResourceMapper;
 
-(0, _injectorJs.Inject)((0, _injectorJs.factory)(_TemplatedUrlJs.TemplatedUrlFromUrl), (0, _injectorJs.factory)(_ResourceBuilderJs2["default"]), (0, _injectorJs.factory)(_PrimaryResourceBuilderJs2["default"]), (0, _injectorJs.factory)(_transformersPrimaryResourceTransformerJs2["default"]), (0, _injectorJs.factory)(_ManyResourceMapperJs2["default"]))(ListResourceMapper);
+(0, _injectorJs.Inject)((0, _injectorJs.factory)(_TemplatedUrlJs.TemplatedUrlFromUrl), (0, _injectorJs.factory)(_ResourceBuilderJs2["default"]), (0, _injectorJs.factory)(_PrimaryResourceBuilderJs2["default"]), (0, _injectorJs.factory)(_transformersPrimaryResourceTransformerJs2["default"]), (0, _injectorJs.factory)(_ManyResourceMapperJs2["default"]), (0, _injectorJs.factory)(_TemporaryTemplatedUrlJs2["default"]))(ListResourceMapper);
 module.exports = exports["default"];

--- a/dist/relayer.es5.js
+++ b/dist/relayer.es5.js
@@ -1,5 +1,5 @@
 define('relayer/jsonpath',[], function() {
-
+  
   if (!Array.isArray) {
     Array.isArray = function(vArg) {
       return Object.prototype.toString.call(vArg) === "[object Array]";
@@ -212,8 +212,1446 @@ define('relayer/jsonpath',[], function() {
   };
 });
 
-define('a1atscript/ToAnnotation',[], function() {
+define('relayer/DataWrapper',["./jsonpath"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var jsonPath = $__0.default;
+  var DataWrapper = function DataWrapper(response) {
+    this._response = response;
+  };
+  ($traceurRuntime.createClass)(DataWrapper, {
+    pathBuild: function(path, value) {
+      var segments = path.split(".");
+      var root = segments.shift();
+      if (root !== "$") {
+        console.log(("root of path " + path + " was " + root + ", not \"$\""));
+        return false;
+      }
+      var target = segments.pop();
+      var thumb = this._response;
+      segments.forEach((function(segment) {
+        if (segment === '') {
+          return ;
+        }
+        if (!thumb[segment]) {
+          thumb[segment] = {};
+        }
+        thumb = thumb[segment];
+      }));
+      thumb[target] = value;
+    },
+    pathGet: function(path) {
+      var temp = jsonPath(this._response, path, {
+        flatten: false,
+        wrap: true
+      });
+      if (temp.length === 0) {
+        return undefined;
+      } else {
+        return temp[0];
+      }
+    },
+    pathSet: function(jsonpath, value) {
+      var path = jsonPath(this._response, jsonpath, {
+        wrap: true,
+        resultType: "path"
+      });
+      if (path && path.length > 0) {
+        path = path[0];
+        if (path[0] !== "$") {
+          console.log(("Warning! root of normalized path '" + path + "' was '" + path[0] + "', not '$'"));
+        }
+        var root = path.shift();
+        var target = path.pop();
+        var thumb = this._response;
+        var $__6 = true;
+        var $__7 = false;
+        var $__8 = undefined;
+        try {
+          for (var $__4 = void 0,
+              $__3 = (path)[$traceurRuntime.toProperty(Symbol.iterator)](); !($__6 = ($__4 = $__3.next()).done); $__6 = true) {
+            var segment = $__4.value;
+            {
+              thumb = thumb[segment];
+            }
+          }
+        } catch ($__9) {
+          $__7 = true;
+          $__8 = $__9;
+        } finally {
+          try {
+            if (!$__6 && $__3.return != null) {
+              $__3.return();
+            }
+          } finally {
+            if ($__7) {
+              throw $__8;
+            }
+          }
+        }
+        if (thumb[target] != value) {
+          this._dirty = true;
+        }
+        thumb[target] = value;
+      } else {}
+    },
+    pathClear: function(jsonpath) {
+      var path = jsonPath(this._response, jsonpath, {
+        wrap: true,
+        resultType: "path"
+      });
+      if (path && path.length === 0) {
+        return ;
+      }
+      path = path[0];
+      if (path[0] !== "$") {
+        console.log(("root of normalized path was '" + path[0] + "', not '$'"));
+      }
+      var root = path.shift();
+      var target = path.pop();
+      var thumb = this._response;
+      var $__6 = true;
+      var $__7 = false;
+      var $__8 = undefined;
+      try {
+        for (var $__4 = void 0,
+            $__3 = (path)[$traceurRuntime.toProperty(Symbol.iterator)](); !($__6 = ($__4 = $__3.next()).done); $__6 = true) {
+          var segment = $__4.value;
+          {
+            thumb = thumb[segment];
+          }
+        }
+      } catch ($__9) {
+        $__7 = true;
+        $__8 = $__9;
+      } finally {
+        try {
+          if (!$__6 && $__3.return != null) {
+            $__3.return();
+          }
+        } finally {
+          if ($__7) {
+            throw $__8;
+          }
+        }
+      }
+      delete thumb[target];
+    }
+  }, {});
+  var $__default = DataWrapper;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
 
+define('relayer/APIError',["./DataWrapper"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var DataWrapper = $__0.default;
+  var APIError = function APIError(responseData) {
+    var $__2;
+    $traceurRuntime.superConstructor($APIError).call(this);
+    this._response = responseData;
+    this.unhandled = [];
+    if (this.constructor.properties) {
+      this.unhandled = Object.keys(this.constructor.properties).filter(($__2 = this, function(name) {
+        return $__2[name] && $__2[name].message;
+      })).map((function(name) {
+        return name;
+      }));
+    }
+  };
+  var $APIError = APIError;
+  ($traceurRuntime.createClass)(APIError, {handleMessage: function(attrName) {
+      if (this[attrName]) {
+        this.unhandled = this.unhandled.filter((function(name) {
+          return name != attrName;
+        }));
+        return this[attrName].message;
+      }
+    }}, {}, DataWrapper);
+  var $__default = APIError;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/decorators/ResourceDecorator',[], function() {
+  
+  var ResourceDecorator = function ResourceDecorator(name) {
+    this.name = name;
+  };
+  ($traceurRuntime.createClass)(ResourceDecorator, {
+    addFunction: function(target, func) {
+      if (!(target.hasOwnProperty(this.name))) {
+        target[this.name] = func;
+      }
+    },
+    resourceApply: function(resource) {},
+    errorsApply: function(errors) {},
+    endpointApply: function(endpoint) {}
+  }, {});
+  var $__default = ResourceDecorator;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/endpoints/Endpoint',[], function() {
+  
+  var Endpoint = function Endpoint() {};
+  ($traceurRuntime.createClass)(Endpoint, {
+    create: function(resource, res, rej) {
+      return this.endpointPromise().then((function(endpoint) {
+        if (endpoint._create) {
+          return endpoint._create(resource);
+        } else {
+          return endpoint.create(resource);
+        }
+      })).then(res, rej);
+    },
+    update: function(resource, res, rej) {
+      return this.endpointPromise().then((function(endpoint) {
+        if (endpoint._update) {
+          return endpoint._update(resource);
+        } else {
+          return endpoint.update(resource);
+        }
+      })).then(res, rej);
+    },
+    load: function(res, rej) {
+      return this.endpointPromise().then((function(endpoint) {
+        if (endpoint._load) {
+          return endpoint._load();
+        } else {
+          return endpoint.load();
+        }
+      })).then(res, rej);
+    },
+    get: function(prop) {
+      for (var args = [],
+          $__1 = 1; $__1 < arguments.length; $__1++)
+        args[$__1 - 1] = arguments[$__1];
+      return this.load().then((function(response) {
+        var $__2;
+        if (typeof response[prop] == 'function') {
+          return ($__2 = response)[prop].apply($__2, $traceurRuntime.spread(args));
+        } else {
+          return response[prop];
+        }
+      }));
+    },
+    remove: function(res, rej) {
+      return this.endpointPromise().then((function(endpoint) {
+        return endpoint._remove();
+      })).then(res, rej);
+    }
+  }, {});
+  var $__default = Endpoint;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/MetaMap',[], function() {
+  
+  var MetaMap = function MetaMap() {
+    this._metadataMap = new Map();
+  };
+  ($traceurRuntime.createClass)(MetaMap, {
+    _getOrCreateMetadata: function(target) {
+      var metadata = this._metadataMap.get(target);
+      if (!metadata) {
+        metadata = new Map();
+        this._metadataMap.set(target, metadata);
+      }
+      return metadata;
+    },
+    defineMetadata: function(key, value, target) {
+      this._getOrCreateMetadata(target).set(key, value);
+    },
+    hasMetadata: function(key, target) {
+      return this._getOrCreateMetadata(target).has(key);
+    },
+    getMetadata: function(key, target) {
+      return this._getOrCreateMetadata(target).get(key);
+    },
+    deleteMetadata: function(key, target) {
+      this._getOrCreateMetadata(target).delete(key);
+    }
+  }, {});
+  var $__default = MetaMap;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/injector',["./MetaMap"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var MetaMap = $__0.default;
+  var metaMap = new MetaMap();
+  function metadataValueOrCall(key, target, cb) {
+    if (metaMap.hasMetadata(key, target)) {
+      return metaMap.getMetadata(key, target);
+    } else {
+      var value = cb();
+      metaMap.defineMetadata(key, value, target);
+      return value;
+    }
+  }
+  function Inject() {
+    for (var dependencies = [],
+        $__4 = 0; $__4 < arguments.length; $__4++)
+      dependencies[$__4] = arguments[$__4];
+    return function(target) {
+      metaMap.defineMetadata('injectables', dependencies, target);
+    };
+  }
+  function factory(Target) {
+    return metadataValueOrCall('factory', Target, (function() {
+      return new FactoryInjectable(Target);
+    }));
+  }
+  function value(Target) {
+    return metadataValueOrCall('value', Target, (function() {
+      return new ValueInjectable(Target);
+    }));
+  }
+  function singleton(Target) {
+    return metadataValueOrCall('singleton', Target, (function() {
+      return new SingletonInjectable(Target);
+    }));
+  }
+  function instance(Target) {
+    return metadataValueOrCall('instance', Target, (function() {
+      return new InstanceInjectable(Target);
+    }));
+  }
+  var Injectable = function Injectable() {};
+  ($traceurRuntime.createClass)(Injectable, {instantiate: function() {
+      for (var args = [],
+          $__5 = 0; $__5 < arguments.length; $__5++)
+        args[$__5] = arguments[$__5];
+      var $__2 = this;
+      return metadataValueOrCall('instantiated', this, (function() {
+        var $__9;
+        var instantiated = ($__9 = $__2)._instantiate.apply($__9, $traceurRuntime.spread(args));
+        injector.recordInstantiation(instantiated);
+        return instantiated;
+      }));
+    }}, {});
+  var ValueInjectable = function ValueInjectable(value) {
+    $traceurRuntime.superConstructor($ValueInjectable).call(this);
+    this.value = value;
+  };
+  var $ValueInjectable = ValueInjectable;
+  ($traceurRuntime.createClass)(ValueInjectable, {_instantiate: function() {
+      return this.value;
+    }}, {}, Injectable);
+  var FactoryInjectable = function FactoryInjectable(Target) {
+    $traceurRuntime.superConstructor($FactoryInjectable).call(this);
+    this.Target = Target;
+  };
+  var $FactoryInjectable = FactoryInjectable;
+  ($traceurRuntime.createClass)(FactoryInjectable, {_instantiate: function() {
+      var $__2 = this;
+      return (function() {
+        var $__9;
+        for (var args = [],
+            $__6 = 0; $__6 < arguments.length; $__6++)
+          args[$__6] = arguments[$__6];
+        return ($__9 = injector).instantiate.apply($__9, $traceurRuntime.spread([instance($__2.Target)], args));
+      });
+    }}, {}, Injectable);
+  var ConstructableInjectable = function ConstructableInjectable(Target) {
+    $traceurRuntime.superConstructor($ConstructableInjectable).call(this);
+    this.Target = Target;
+  };
+  var $ConstructableInjectable = ConstructableInjectable;
+  ($traceurRuntime.createClass)(ConstructableInjectable, {_instantiate: function() {
+      for (var args = [],
+          $__6 = 0; $__6 < arguments.length; $__6++)
+        args[$__6] = arguments[$__6];
+      var finalArgs;
+      if (metaMap.hasMetadata('injectables', this.Target)) {
+        var instantiatedInjectables = injector.instantiateInjectables(metaMap.getMetadata('injectables', this.Target));
+        finalArgs = instantiatedInjectables.concat(args);
+      } else {
+        finalArgs = args;
+      }
+      return new (Function.prototype.bind.apply(this.Target, $traceurRuntime.spread([null], finalArgs)))();
+    }}, {}, Injectable);
+  var SingletonInjectable = function SingletonInjectable() {
+    $traceurRuntime.superConstructor($SingletonInjectable).apply(this, arguments);
+    ;
+  };
+  var $SingletonInjectable = SingletonInjectable;
+  ($traceurRuntime.createClass)(SingletonInjectable, {}, {}, ConstructableInjectable);
+  var InstanceInjectable = function InstanceInjectable() {
+    $traceurRuntime.superConstructor($InstanceInjectable).apply(this, arguments);
+    ;
+  };
+  var $InstanceInjectable = InstanceInjectable;
+  ($traceurRuntime.createClass)(InstanceInjectable, {instantiate: function() {
+      var $__9;
+      for (var args = [],
+          $__7 = 0; $__7 < arguments.length; $__7++)
+        args[$__7] = arguments[$__7];
+      return ($__9 = this)._instantiate.apply($__9, $traceurRuntime.spread(args));
+    }}, {}, ConstructableInjectable);
+  var Injector = function Injector() {
+    this._instantiations = [];
+  };
+  ($traceurRuntime.createClass)(Injector, {
+    recordInstantiation: function(instantiated) {
+      this._instantiations.push(instantiated);
+    },
+    reset: function() {
+      this._instantiations.forEach((function(instantiated) {
+        return metaMap.deleteMetadata("instantiated", instantiated);
+      }));
+    },
+    instantiateInjectables: function(injectables) {
+      var $__2 = this;
+      return injectables.map((function(injectable) {
+        return $__2.instantiate(injectable);
+      }));
+    },
+    instantiate: function(Target) {
+      var $__9;
+      for (var args = [],
+          $__8 = 1; $__8 < arguments.length; $__8++)
+        args[$__8 - 1] = arguments[$__8];
+      var injectable;
+      if (!(Target instanceof Injectable)) {
+        injectable = singleton(Target);
+      } else {
+        injectable = Target;
+      }
+      return ($__9 = injectable).instantiate.apply($__9, $traceurRuntime.spread(args));
+    },
+    get XingPromise() {
+      this._XingPromise = this._XingPromise || new ValueInjectable();
+      return this._XingPromise;
+    }
+  }, {});
+  var injector = new Injector();
+  var $__default = injector;
+  return {
+    get Inject() {
+      return Inject;
+    },
+    get factory() {
+      return factory;
+    },
+    get value() {
+      return value;
+    },
+    get singleton() {
+      return singleton;
+    },
+    get instance() {
+      return instance;
+    },
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/endpoints/ResolvedEndpoint',["./Endpoint", "../injector"], function($__0,$__2) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  var Endpoint = $__0.default;
+  var $__3 = $__2,
+      Inject = $__3.Inject,
+      value = $__3.value,
+      injector = $__3.default;
+  var ResolvedEndpoint = function ResolvedEndpoint(Promise, transport, templatedUrl) {
+    var resourceTransformers = arguments[3] !== (void 0) ? arguments[3] : [];
+    var createResourceTransformers = arguments[4] !== (void 0) ? arguments[4] : [];
+    var $__4;
+    $traceurRuntime.superConstructor($ResolvedEndpoint).call(this);
+    this.transport = transport;
+    this.templatedUrl = templatedUrl;
+    if (Array.isArray(resourceTransformers)) {
+      this.resourceTransformers = resourceTransformers;
+    } else {
+      this.resourceTransformers = [resourceTransformers];
+    }
+    if (Array.isArray(createResourceTransformers)) {
+      this.createResourceTransformers = createResourceTransformers;
+    } else {
+      this.createResourceTransformers = [createResourceTransformers];
+    }
+    this.endpointPromise = ($__4 = this, function() {
+      return Promise.resolve($__4);
+    });
+  };
+  var $ResolvedEndpoint = ResolvedEndpoint;
+  ($traceurRuntime.createClass)(ResolvedEndpoint, {
+    _load: function() {
+      var response = this.transport.get(this.templatedUrl.url, this.templatedUrl.etag);
+      return this._transformResponse(this.resourceTransformers, response);
+    },
+    _update: function(resource) {
+      var request = this._transformRequest(this.resourceTransformers, resource);
+      var response = this.transport.put(this.templatedUrl.url, request, this.templatedUrl.etag);
+      return this._transformResponse(this.resourceTransformers, response);
+    },
+    _create: function(resource) {
+      var request = this._transformRequest(this.createResourceTransformers, resource);
+      var response = this.transport.post(this.templatedUrl.url, request);
+      return this._transformResponse(this.createResourceTransformers, response);
+    },
+    _transformResponse: function(transformers, response) {
+      var $__4 = this;
+      return transformers.reduce((function(interimResponse, transformer) {
+        return transformer.transformResponse($__4, interimResponse);
+      }), response);
+    },
+    _transformRequest: function(transformers, request) {
+      var $__4 = this;
+      return transformers.slice(0).reverse().reduce((function(interimRequest, transformer) {
+        return transformer.transformRequest($__4, interimRequest);
+      }), request);
+    },
+    _remove: function() {
+      return this.transport.delete(this.templatedUrl.url);
+    }
+  }, {}, Endpoint);
+  var $__default = ResolvedEndpoint;
+  Inject(injector.XingPromise)(ResolvedEndpoint);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/endpoints/LoadedDataEndpoint',["./ResolvedEndpoint", "../injector"], function($__0,$__2) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  var ResolvedEndpoint = $__0.default;
+  var $__3 = $__2,
+      Inject = $__3.Inject,
+      injector = $__3.default;
+  var LoadedDataEndpoint = function LoadedDataEndpoint(Promise, resolvedEndpoint, resource) {
+    var resourceTransformers = arguments[3] !== (void 0) ? arguments[3] : [];
+    var createResourceTransformers = arguments[4] !== (void 0) ? arguments[4] : [];
+    $traceurRuntime.superConstructor($LoadedDataEndpoint).call(this, Promise, resolvedEndpoint.transport, resolvedEndpoint.templatedUrl, resolvedEndpoint.resourceTransformers.concat(resourceTransformers), resolvedEndpoint.createResourceTransformers.concat(createResourceTransformers));
+    this.resource = resource;
+    this.Promise = Promise;
+    this.data = resolvedEndpoint._transformRequest(resolvedEndpoint.resourceTransformers, resource);
+  };
+  var $LoadedDataEndpoint = LoadedDataEndpoint;
+  ($traceurRuntime.createClass)(LoadedDataEndpoint, {
+    _load: function() {
+      return this._transformResponse(this.resourceTransformers, this.Promise.resolve({
+        data: this.data,
+        etag: this.templatedUrl.etag
+      }));
+    },
+    _update: function(resource) {
+      var $__4 = this;
+      var request = this._transformRequest(this.resourceTransformers, resource);
+      var response = this.transport.put(this.templatedUrl.url, request);
+      response = response.then((function(data) {
+        $__4.data = data.data;
+        return data;
+      }));
+      return this._transformResponse(this.resourceTransformers, response);
+    }
+  }, {}, ResolvedEndpoint);
+  var $__default = LoadedDataEndpoint;
+  Inject(injector.XingPromise)(LoadedDataEndpoint);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/ResourceTransformer',[], function() {
+  
+  var ResourceTransformer = function ResourceTransformer() {};
+  ($traceurRuntime.createClass)(ResourceTransformer, {
+    transformRequest: function(endpoint, resource) {
+      return resource;
+    },
+    transformResponse: function(endpoint, response) {
+      return response;
+    }
+  }, {});
+  var $__default = ResourceTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/EmbeddedPropertyTransformer',["./ResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var ResourceTransformer = $__0.default;
+  var EmbeddedPropertyTransformer = function EmbeddedPropertyTransformer(path) {
+    $traceurRuntime.superConstructor($EmbeddedPropertyTransformer).call(this);
+    this.path = path;
+  };
+  var $EmbeddedPropertyTransformer = EmbeddedPropertyTransformer;
+  ($traceurRuntime.createClass)(EmbeddedPropertyTransformer, {
+    transformRequest: function(endpoint, value) {
+      var resource = endpoint.resource;
+      resource.pathSet(this.path, value);
+      return resource;
+    },
+    transformResponse: function(endpoint, response) {
+      var $__2 = this;
+      return response.then((function(resource) {
+        endpoint.resource = resource;
+        return resource.pathGet($__2.path);
+      })).catch((function(error) {
+        throw error.pathGet($__2.path);
+      }));
+    }
+  }, {}, ResourceTransformer);
+  var $__default = EmbeddedPropertyTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/endpoints/PromiseEndpoint',["./Endpoint"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var Endpoint = $__0.default;
+  var PromiseEndpoint = function PromiseEndpoint(promiseFunction) {
+    $traceurRuntime.superConstructor($PromiseEndpoint).call(this);
+    this.endpointPromise = promiseFunction;
+  };
+  var $PromiseEndpoint = PromiseEndpoint;
+  ($traceurRuntime.createClass)(PromiseEndpoint, {}, {}, Endpoint);
+  var $__default = PromiseEndpoint;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/decorators/JsonPropertyDecorator',["./ResourceDecorator", "../endpoints/LoadedDataEndpoint", "../transformers/EmbeddedPropertyTransformer", "../endpoints/PromiseEndpoint", "../injector"], function($__0,$__2,$__4,$__6,$__8) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  var ResourceDecorator = $__0.default;
+  var LoadedDataEndpoint = $__2.default;
+  var EmbeddedPropertyTransformer = $__4.default;
+  var PromiseEndpoint = $__6.default;
+  var $__9 = $__8,
+      Inject = $__9.Inject,
+      factory = $__9.factory;
+  var JsonPropertyDecorator = function JsonPropertyDecorator(loadedDataEndpointFactory, embeddedPropertyTransformerFactory, promiseEndpointFactory, name, path, value, options) {
+    $traceurRuntime.superConstructor($JsonPropertyDecorator).call(this, name);
+    this.path = path;
+    this.options = options || {};
+    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
+    this.embeddedPropertyTransformerFactory = embeddedPropertyTransformerFactory;
+    this.promiseEndpointFactory = promiseEndpointFactory;
+    this.value = value;
+  };
+  var $JsonPropertyDecorator = JsonPropertyDecorator;
+  ($traceurRuntime.createClass)(JsonPropertyDecorator, {
+    recordApply: function(target) {
+      target.constructor.properties[this.name] = this.path;
+      if (!(target.hasOwnProperty(this.name))) {
+        var afterSet = this.options.afterSet;
+        var path = this.path;
+        Object.defineProperty(target, this.name, {
+          enumerable: true,
+          configurable: true,
+          get: function() {
+            return this.pathGet(path);
+          },
+          set: function(value) {
+            var result = this.pathSet(path, value);
+            if (afterSet) {
+              afterSet.call(this);
+            }
+            return result;
+          }
+        });
+      }
+    },
+    resourceApply: function(resource) {
+      if (this.value !== undefined) {
+        resource.setInitialValue(this.path, this.value);
+      }
+      this.recordApply(resource);
+    },
+    errorsApply: function(errors) {
+      this.recordApply(errors);
+    },
+    get endpointFn() {
+      if (!this._endpointFn) {
+        var path = this.path;
+        var promiseEndpointFactory = this.promiseEndpointFactory;
+        var loadedDataEndpointFactory = this.loadedDataEndpointFactory;
+        var embeddedPropertyTransformerFactory = this.embeddedPropertyTransformerFactory;
+        this._endpointFn = function() {
+          var uriParams = arguments[0] !== (void 0) ? arguments[0] : {};
+          var $__10 = this;
+          var newPromise = (function() {
+            return $__10.load().then((function(resource) {
+              return loadedDataEndpointFactory(resource.self(), resource, [embeddedPropertyTransformerFactory(path)]);
+            }));
+          });
+          var newEndpoint = promiseEndpointFactory(newPromise);
+          return newEndpoint;
+        };
+      }
+      return this._endpointFn;
+    },
+    endpointApply: function(target) {
+      this.addFunction(target, this.endpointFn);
+    }
+  }, {}, ResourceDecorator);
+  var $__default = JsonPropertyDecorator;
+  Inject(factory(LoadedDataEndpoint), factory(EmbeddedPropertyTransformer), factory(PromiseEndpoint))(JsonPropertyDecorator);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/TemplatedUrl',[], function() {
+  
+  var TemplatedUrl = function TemplatedUrl(uriTemplate) {
+    var uriParams = arguments[1] !== (void 0) ? arguments[1] : {};
+    this._uriTemplate = new UriTemplate(uriTemplate);
+    this._uriParams = uriParams;
+    this._paths = [];
+    this._url = this._uriTemplate.fillFromObject(this._uriParams);
+  };
+  ($traceurRuntime.createClass)(TemplatedUrl, {
+    get uriTemplate() {
+      return this._uriTemplate.toString();
+    },
+    get uriParams() {
+      return this._uriParams;
+    },
+    get url() {
+      return this._url;
+    },
+    _setUrl: function(url) {
+      var uriParams = this._uriTemplate.fromUri(url);
+      this._uriParams = uriParams;
+      this._url = url;
+    },
+    addDataPathLink: function(resource, path) {
+      var overwrite = arguments[2] !== (void 0) ? arguments[2] : true;
+      if (overwrite) {
+        var newUrl = resource.pathGet(path);
+        if (newUrl) {
+          this._setUrl(newUrl);
+          this._paths.forEach((function(path) {
+            path.resource.pathSet(path.path, newUrl);
+          }));
+        }
+      } else {
+        resource.pathSet(path, this.url);
+      }
+      this._paths.push({
+        resource: resource,
+        path: path
+      });
+    },
+    removeDataPathLink: function(resource, path) {
+      this._paths = this._paths.filter((function(pathLink) {
+        return (pathLink.resource != resource) || (pathLink.path != path);
+      }));
+    }
+  }, {});
+  var TemplatedUrlFromUrl = function TemplatedUrlFromUrl(uriTemplate, url) {
+    $traceurRuntime.superConstructor($TemplatedUrlFromUrl).call(this, uriTemplate);
+    $traceurRuntime.superGet(this, $TemplatedUrlFromUrl.prototype, "_setUrl").call(this, url);
+  };
+  var $TemplatedUrlFromUrl = TemplatedUrlFromUrl;
+  ($traceurRuntime.createClass)(TemplatedUrlFromUrl, {}, {}, TemplatedUrl);
+  return {
+    get TemplatedUrl() {
+      return TemplatedUrl;
+    },
+    get TemplatedUrlFromUrl() {
+      return TemplatedUrlFromUrl;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/RelationshipUtilities',["./TemplatedUrl"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var TemplatedUrl = $__0.TemplatedUrl;
+  var RelationshipUtilities = function RelationshipUtilities() {
+    ;
+  };
+  ($traceurRuntime.createClass)(RelationshipUtilities, {addMethods: function(target, resource, name) {
+      target.get = function() {
+        return resource.relationships[name];
+      };
+      target.present = function() {
+        return resource.relationships[name] ? true : false;
+      };
+      target.set = function(newRelationship) {
+        var linksPath = resource.constructor.relationships[name].linksPath;
+        if (resource.relationships[name] instanceof TemplatedUrl) {
+          resource.relationships[name].removeDataPathLink(resource, linksPath);
+          if (!newRelationship) {
+            resource.pathSet(linksPath, "");
+          }
+        }
+        if (newRelationship instanceof TemplatedUrl) {
+          newRelationship.addDataPathLink(resource, linksPath, false);
+        }
+        resource.relationships[name] = newRelationship;
+        if (!resource.relationships[name]) {
+          delete resource.relationships[name];
+        }
+      };
+    }}, {});
+  var $__default = RelationshipUtilities;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/decorators/RelatedResourceDecorator',["./ResourceDecorator", "../TemplatedUrl", "../injector", "../endpoints/PromiseEndpoint", "../RelationshipUtilities"], function($__0,$__2,$__4,$__6,$__8) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  var ResourceDecorator = $__0.default;
+  var TemplatedUrl = $__2.TemplatedUrl;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var PromiseEndpoint = $__6.default;
+  var RelationshipUtilities = $__8.default;
+  var RelatedResourceDecorator = function RelatedResourceDecorator(promiseEndpointFactory, relationshipUtilities, name, relationship) {
+    $traceurRuntime.superConstructor($RelatedResourceDecorator).call(this, name);
+    this.promiseEndpointFactory = promiseEndpointFactory;
+    this.relationshipUtilities = relationshipUtilities;
+    this.relationship = relationship;
+  };
+  var $RelatedResourceDecorator = RelatedResourceDecorator;
+  ($traceurRuntime.createClass)(RelatedResourceDecorator, {
+    get resourceFn() {
+      if (!this._resourceFn) {
+        var name = this.name;
+        var relationship = this.relationship;
+        var promiseEndpointFactory = this.promiseEndpointFactory;
+        var relationshipUtilities = this.relationshipUtilities;
+        this._resourceFn = function(uriParams) {
+          var recursiveCall = arguments[1] !== (void 0) ? arguments[1] : false;
+          var $__10 = this;
+          if (relationship.async && this.isPersisted) {
+            var endpoint;
+            if (!this.relationships[name]) {
+              if (recursiveCall === false) {
+                endpoint = promiseEndpointFactory((function() {
+                  return $__10.self().load().then((function(resource) {
+                    return resource[name](uriParams, true);
+                  }));
+                }));
+              } else {
+                throw "Error: Unable to find relationship, even on canonical resource";
+              }
+            } else if (this.relationships[name] instanceof TemplatedUrl) {
+              endpoint = relationship.linkedEndpoint(this, uriParams);
+            } else {
+              endpoint = relationship.embeddedEndpoint(this, uriParams);
+            }
+            relationship.ResourceClass.resourceDescription.applyToEndpoint(endpoint);
+            relationshipUtilities.addMethods(endpoint, this, name);
+            return endpoint;
+          } else {
+            if (this.relationships[name] instanceof TemplatedUrl) {
+              throw "Error: non-async relationships must be embedded";
+            } else {
+              if (uriParams) {
+                return this.relationships[name][uriParams];
+              } else {
+                return this.relationships[name];
+              }
+            }
+          }
+        };
+      }
+      return this._resourceFn;
+    },
+    get errorFn() {
+      if (!this._errorFn) {
+        var name = this.name;
+        var path = this.path;
+        var relationship = this.relationship;
+        this._errorFn = function(uriParams) {
+          if (this.relationships[name] instanceof TemplatedUrl) {
+            throw "Error: non-async relationships must be embedded";
+          } else {
+            if (uriParams) {
+              return this.relationships[name][uriParams];
+            } else {
+              return this.relationships[name];
+            }
+          }
+        };
+      }
+      return this._errorFn;
+    },
+    get endpointFn() {
+      if (!this._endpointFn) {
+        var name = this.name;
+        var description = this.relationship.ResourceClass.resourceDescription;
+        var relationship = this.relationship;
+        var promiseEndpointFactory = this.promiseEndpointFactory;
+        this._endpointFn = function() {
+          var uriParams = arguments[0] !== (void 0) ? arguments[0] : {};
+          var $__10 = this;
+          var newPromise = (function() {
+            return $__10.load().then((function(resource) {
+              if (relationship.async) {
+                return resource[name](uriParams);
+              } else {
+                var endpoint = relationship.embeddedEndpoint(resource, uriParams);
+                description.applyToEndpoint(endpoint);
+                return endpoint;
+              }
+            }));
+          });
+          var newEndpoint = promiseEndpointFactory(newPromise);
+          relationship.decorateEndpoint(newEndpoint, uriParams);
+          description.applyToEndpoint(newEndpoint);
+          return newEndpoint;
+        };
+      }
+      return this._endpointFn;
+    },
+    resourceApply: function(target) {
+      target.constructor.relationships[this.name] = this.relationship;
+      this.addFunction(target, this.resourceFn);
+    },
+    errorsApply: function(target) {
+      target.constructor.relationships[this.name] = this.relationship;
+      this.addFunction(target, this.errorFn);
+    },
+    endpointApply: function(target) {
+      this.addFunction(target, this.endpointFn);
+    }
+  }, {}, ResourceDecorator);
+  var $__default = RelatedResourceDecorator;
+  Inject(factory(PromiseEndpoint), RelationshipUtilities)(RelatedResourceDecorator);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/relationshipDescriptions/RelationshipDescription',[], function() {
+  
+  var RelationshipDescription = function RelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues) {
+    this.initializer = relationshipInitializerFactory(ResourceClass, initialValues);
+    this.mapperFactory = resourceMapperFactory;
+    this.serializerFactory = resourceSerializerFactory;
+    this.inflector = inflector;
+    this.name = name;
+    this.ResourceClass = ResourceClass;
+    this.initialValues = initialValues;
+    this.async = true;
+    if (initialValues === undefined) {
+      this.initializeOnCreate = false;
+    } else {
+      this.initializeOnCreate = true;
+    }
+  };
+  ($traceurRuntime.createClass)(RelationshipDescription, {
+    get linksPath() {
+      this._linksPath = this._linksPath || ("$.links." + this.inflector.underscore(this.name));
+      return this._linksPath;
+    },
+    set linksPath(linksPath) {
+      this._linksPath = linksPath;
+      return this._linksPath;
+    },
+    get dataPath() {
+      this._dataPath = this._dataPath || ("$.data." + this.inflector.underscore(this.name));
+      return this._dataPath;
+    },
+    set dataPath(dataPath) {
+      this._dataPath = dataPath;
+      return this._dataPath;
+    },
+    decorateEndpoint: function(endpoint, uriParams) {}
+  }, {});
+  var $__default = RelationshipDescription;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/initializers/RelationshipInitializer',[], function() {
+  
+  var RelationshipInitializer = function RelationshipInitializer(ResourceClass, initialValues) {
+    this.ResourceClass = ResourceClass;
+    this.initialValues = initialValues;
+  };
+  ($traceurRuntime.createClass)(RelationshipInitializer, {initialize: function() {}}, {});
+  var $__default = RelationshipInitializer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/initializers/SingleRelationshipInitializer',["./RelationshipInitializer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var RelationshipInitializer = $__0.default;
+  var SingleRelationshipInitializer = function SingleRelationshipInitializer() {
+    $traceurRuntime.superConstructor($SingleRelationshipInitializer).apply(this, arguments);
+    ;
+  };
+  var $SingleRelationshipInitializer = SingleRelationshipInitializer;
+  ($traceurRuntime.createClass)(SingleRelationshipInitializer, {initialize: function() {
+      var $__2 = this;
+      var relationship = new this.ResourceClass();
+      if (this.initialValues) {
+        Object.keys(this.initialValues).forEach((function(property) {
+          relationship[property] = $__2.initialValues[property];
+        }));
+      }
+      return relationship;
+    }}, {}, RelationshipInitializer);
+  var $__default = SingleRelationshipInitializer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/mappers/Mapper',[], function() {
+  
+  var Mapper = function Mapper(transport, response, relationshipDescription) {
+    var useErrors = arguments[3] !== (void 0) ? arguments[3] : false;
+    this.transport = transport;
+    this.response = response;
+    this.relationshipDescription = relationshipDescription;
+    this.useErrors = useErrors;
+  };
+  ($traceurRuntime.createClass)(Mapper, {
+    get ResourceClass() {
+      if (this.useErrors) {
+        return this.relationshipDescription.ResourceClass.errorClass;
+      } else {
+        return this.relationshipDescription.ResourceClass;
+      }
+    },
+    get mapperFactory() {
+      return this.relationshipDescription.mapperFactory;
+    },
+    get serializerFactory() {
+      return this.relationshipDescription.serializerFactory;
+    },
+    map: function() {
+      this.initializeModel();
+      this.mapNestedRelationships();
+      return this.mapped;
+    }
+  }, {});
+  var $__default = Mapper;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/ThrowErrorTransformer',["./ResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var ResourceTransformer = $__0.default;
+  var ThrowErrorTransformer = function ThrowErrorTransformer() {
+    $traceurRuntime.superConstructor($ThrowErrorTransformer).apply(this, arguments);
+    ;
+  };
+  var $ThrowErrorTransformer = ThrowErrorTransformer;
+  ($traceurRuntime.createClass)(ThrowErrorTransformer, {
+    transformRequest: function(endpoint, resource) {
+      throw "This Resource Cannot Be Updated Or Created";
+    },
+    transformResponse: function(endpoint, response) {
+      throw "There is no Resource To Create From This Response";
+    }
+  }, {}, ResourceTransformer);
+  var $__default = ThrowErrorTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/PrimaryResourceTransformer',["./ResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var ResourceTransformer = $__0.default;
+  var PrimaryResourceTransformer = function PrimaryResourceTransformer(relationshipDescription) {
+    $traceurRuntime.superConstructor($PrimaryResourceTransformer).call(this);
+    this.relationshipDescription = relationshipDescription;
+  };
+  var $PrimaryResourceTransformer = PrimaryResourceTransformer;
+  ($traceurRuntime.createClass)(PrimaryResourceTransformer, {
+    get primaryResourceSerializerFactory() {
+      return this.relationshipDescription.serializerFactory;
+    },
+    get primaryResourceMapperFactory() {
+      return this.relationshipDescription.mapperFactory;
+    },
+    transformRequest: function(endpoint, resource) {
+      return this.primaryResourceSerializerFactory(resource).serialize();
+    },
+    transformResponse: function(endpoint, response) {
+      var $__2 = this;
+      return response.then((function(resolvedResponse) {
+        endpoint.templatedUrl.etag = resolvedResponse.etag;
+        return $__2.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, $__2.relationshipDescription, endpoint).map();
+      })).catch((function(resolvedError) {
+        throw $__2.primaryResourceMapperFactory(endpoint.transport, resolvedError.data, $__2.relationshipDescription, endpoint, true).map();
+      }));
+    }
+  }, {}, ResourceTransformer);
+  var $__default = PrimaryResourceTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/CreateResourceTransformer',["./PrimaryResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var PrimaryResourceTransformer = $__0.default;
+  var CreateResourceTransformer = function CreateResourceTransformer(relationshipDescription, uriTemplate) {
+    $traceurRuntime.superConstructor($CreateResourceTransformer).call(this, relationshipDescription);
+    this.uriTemplate = uriTemplate;
+  };
+  var $CreateResourceTransformer = CreateResourceTransformer;
+  ($traceurRuntime.createClass)(CreateResourceTransformer, {transformResponse: function(endpoint, response) {
+      var $__2 = this;
+      return response.then((function(resolvedResponse) {
+        var resourceMapper = $__2.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, $__2.relationshipDescription);
+        resourceMapper.uriTemplate = $__2.uriTemplate;
+        var resource = resourceMapper.map();
+        resource.templatedUrl.etag = resolvedResponse.etag;
+        return resource;
+      })).catch((function(resolvedError) {
+        throw $__2.primaryResourceMapperFactory(endpoint.transport, resolvedError.data, $__2.relationshipDescription, null, true).map();
+      }));
+    }}, {}, PrimaryResourceTransformer);
+  var $__default = CreateResourceTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/ResourceBuilder',["./TemplatedUrl", "./endpoints/ResolvedEndpoint", "./transformers/ThrowErrorTransformer", "./transformers/CreateResourceTransformer", "./injector"], function($__0,$__2,$__4,$__6,$__8) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  var TemplatedUrlFromUrl = $__0.TemplatedUrlFromUrl;
+  var ResolvedEndpoint = $__2.default;
+  var ThrowErrorTransformer = $__4.default;
+  var CreateResourceTransformer = $__6.default;
+  var $__9 = $__8,
+      Inject = $__9.Inject,
+      factory = $__9.factory;
+  var ResourceBuilder = function ResourceBuilder(templatedUrlFromUrlFactory, resolvedEndpointFactory, throwErrorTransformerFactory, createResourceTransformerFactory, transport, response, primaryResourceTransformer, ResourceClass, relationshipDescription) {
+    this.transport = transport;
+    this.ResourceClass = ResourceClass;
+    this.relationshipDescription = relationshipDescription;
+    this.templatedUrlFromUrlFactory = templatedUrlFromUrlFactory;
+    this.resolvedEndpointFactory = resolvedEndpointFactory;
+    this.throwErrorTransformerFactory = throwErrorTransformerFactory;
+    this.createResourceTransformerFactory = createResourceTransformerFactory;
+    this.response = response;
+    this.primaryResourceTransformer = primaryResourceTransformer;
+  };
+  ($traceurRuntime.createClass)(ResourceBuilder, {build: function() {
+      var uriTemplate = arguments[0] !== (void 0) ? arguments[0] : null;
+      var resource = new this.ResourceClass(this.response);
+      if (resource.pathGet("$.links.self")) {
+        if (uriTemplate) {
+          resource.templatedUrl = this.templatedUrlFromUrlFactory(uriTemplate, resource.pathGet("$.links.self"));
+        } else {
+          resource.templatedUrl = this.templatedUrlFromUrlFactory(resource.pathGet("$.links.self"), resource.pathGet("$.links.self"));
+        }
+        resource.templatedUrl.addDataPathLink(resource, "$.links.self");
+        if (this.relationshipDescription.canCreate) {
+          var createUriTemplate = uriTemplate || resource.pathGet("$.links.template");
+          var createResourceTransformer = this.createResourceTransformerFactory(this.relationshipDescription.createRelationshipDescription, createUriTemplate);
+        } else {
+          var createResourceTransformer = this.throwErrorTransformerFactory();
+        }
+        var endpoint = this.resolvedEndpointFactory(this.transport, resource.templatedUrl, this.primaryResourceTransformer, createResourceTransformer);
+        resource.self = function() {
+          return endpoint;
+        };
+      }
+      return resource;
+    }}, {});
+  var $__default = ResourceBuilder;
+  Inject(factory(TemplatedUrlFromUrl), factory(ResolvedEndpoint), factory(ThrowErrorTransformer), factory(CreateResourceTransformer))(ResourceBuilder);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/PrimaryResourceBuilder',[], function() {
+  
+  var PrimaryResourceBuilder = function PrimaryResourceBuilder(response, ResourceClass) {
+    this.response = response;
+    this.ResourceClass = ResourceClass;
+  };
+  ($traceurRuntime.createClass)(PrimaryResourceBuilder, {build: function(endpoint) {
+      var resource = new this.ResourceClass(this.response);
+      resource.templatedUrl = endpoint.templatedUrl;
+      resource.templatedUrl.addDataPathLink(resource, "$.links.self");
+      resource.self = function() {
+        return endpoint;
+      };
+      return resource;
+    }}, {});
+  var $__default = PrimaryResourceBuilder;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/mappers/ResourceMapper',["./Mapper", "../TemplatedUrl", "../ResourceBuilder", "../PrimaryResourceBuilder", "../transformers/PrimaryResourceTransformer", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  var Mapper = $__0.default;
+  var TemplatedUrlFromUrl = $__2.TemplatedUrlFromUrl;
+  var ResourceBuilder = $__4.default;
+  var PrimaryResourceBuilder = $__6.default;
+  var PrimaryResourceTransformer = $__8.default;
+  var $__11 = $__10,
+      Inject = $__11.Inject,
+      factory = $__11.factory;
+  var ResourceMapper = function ResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, transport, response, relationshipDescription) {
+    var endpoint = arguments[7] !== (void 0) ? arguments[7] : null;
+    var useErrors = arguments[8] !== (void 0) ? arguments[8] : false;
+    $traceurRuntime.superConstructor($ResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
+    this.primaryResourceTransformerFactory = primaryResourceTransformerFactory;
+    this.templatedUrlFromUrlFactory = templatedUrlFromUrlFactory;
+    this.resourceBuilderFactory = resourceBuilderFactory;
+    this.primaryResourceBuilderFactory = primaryResourceBuilderFactory;
+    this.endpoint = endpoint;
+  };
+  var $ResourceMapper = ResourceMapper;
+  ($traceurRuntime.createClass)(ResourceMapper, {
+    initializeModel: function() {
+      if (this.endpoint) {
+        this.mapped = this.primaryResourceBuilderFactory(this.response, this.ResourceClass).build(this.endpoint);
+      } else {
+        this.mapped = this.resourceBuilderFactory(this.transport, this.response, this.primaryResourceTransformer, this.ResourceClass, this.relationshipDescription).build(this.uriTemplate);
+      }
+    },
+    get primaryResourceTransformer() {
+      this._primaryResourceTransformer = this._primaryResourceTransformer || this.primaryResourceTransformerFactory(this.relationshipDescription);
+      return this._primaryResourceTransformer;
+    },
+    mapNestedRelationships: function() {
+      var relationship;
+      this.mapped.relationships = {};
+      for (var relationshipName in this.ResourceClass.relationships) {
+        if (typeof this.ResourceClass.relationships[relationshipName] == 'object') {
+          relationship = this.ResourceClass.relationships[relationshipName];
+          if (this.mapped.pathGet(relationship.dataPath)) {
+            var subMapper = relationship.mapperFactory(this.transport, this.mapped.pathGet(relationship.dataPath), relationship, this.useErrors);
+            this.mapped.relationships[relationshipName] = subMapper.map();
+          } else if (this.mapped.pathGet(relationship.linksPath)) {
+            var templatedUrl = this.templatedUrlFromUrlFactory(this.mapped.pathGet(relationship.linksPath), this.mapped.pathGet(relationship.linksPath));
+            templatedUrl.addDataPathLink(this.mapped, relationship.linksPath);
+            this.mapped.relationships[relationshipName] = templatedUrl;
+          }
+        }
+      }
+    }
+  }, {}, Mapper);
+  var $__default = ResourceMapper;
+  Inject(factory(TemplatedUrlFromUrl), factory(ResourceBuilder), factory(PrimaryResourceBuilder), factory(PrimaryResourceTransformer))(ResourceMapper);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/serializers/Serializer',[], function() {
+  
+  var Serializer = function Serializer(resource) {
+    this.resource = resource;
+  };
+  ($traceurRuntime.createClass)(Serializer, {serialize: function() {}}, {});
+  var $__default = Serializer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/serializers/ResourceSerializer',["./Serializer", "../TemplatedUrl"], function($__0,$__2) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  var Serializer = $__0.default;
+  var TemplatedUrl = $__2.TemplatedUrl;
+  var ResourceSerializer = function ResourceSerializer() {
+    $traceurRuntime.superConstructor($ResourceSerializer).apply(this, arguments);
+    ;
+  };
+  var $ResourceSerializer = ResourceSerializer;
+  ($traceurRuntime.createClass)(ResourceSerializer, {serialize: function() {
+      var $__4 = this;
+      var relationship;
+      Object.keys(this.resource.relationships).forEach((function(relationshipName) {
+        var relationship = $__4.resource.relationships[relationshipName];
+        if (!(relationship instanceof TemplatedUrl)) {
+          var relationshipDefinition = $__4.resource.constructor.relationships[relationshipName];
+          var serializer = relationshipDefinition.serializerFactory(relationship);
+          $__4.resource.pathSet(relationshipDefinition.dataPath, serializer.serialize());
+        }
+      }));
+      return this.resource.response;
+    }}, {}, Serializer);
+  var $__default = ResourceSerializer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('a1atscript/ToAnnotation',[], function() {
+  
   function defineAnnotation(target, AnnotationClass, callParams) {
     var oldAnnotation = Object.getOwnPropertyDescriptor(target, 'annotations');
     if (oldAnnotation) {
@@ -281,7 +1719,7 @@ define('a1atscript/ToAnnotation',[], function() {
 });
 
 define('a1atscript/annotations',["./ToAnnotation"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var ToAnnotation = $__0.ToAnnotation;
@@ -457,7 +1895,7 @@ define('a1atscript/annotations',["./ToAnnotation"], function($__0) {
 });
 
 define('a1atscript/AnnotationFinder',[], function() {
-
+  
   var AnnotationFinder = function AnnotationFinder(AnnotatedClass) {
     this.AnnotatedClass = AnnotatedClass;
   };
@@ -492,7 +1930,7 @@ define('a1atscript/AnnotationFinder',[], function() {
 });
 
 define('a1atscript/ng2Directives/Ng2Directive',[], function() {
-
+  
   var Ng2Directive = function Ng2Directive(descriptor) {
     this.selector = descriptor.selector;
     this.properties = descriptor.properties || descriptor.bind;
@@ -512,7 +1950,7 @@ define('a1atscript/ng2Directives/Ng2Directive',[], function() {
 });
 
 define('a1atscript/ng2Directives/Component',["./Ng2Directive", "../ToAnnotation"], function($__0,$__2) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -569,7 +2007,7 @@ define('a1atscript/ng2Directives/Component',["./Ng2Directive", "../ToAnnotation"
 });
 
 define('a1atscript/ng2Directives/SelectorMatcher',[], function() {
-
+  
   var SPECIAL_CHARS_REGEXP = /([\:\-\_]+(.))/g;
   var MOZ_HACK_REGEXP = /^moz([A-Z])/;
   var SelectorMatcher = function SelectorMatcher(selector) {
@@ -620,7 +2058,7 @@ define('a1atscript/ng2Directives/SelectorMatcher',[], function() {
 });
 
 define('a1atscript/router/ComponentMapper',["../annotations", "../ng2Directives/Component", "../AnnotationFinder", "../ng2Directives/SelectorMatcher"], function($__0,$__2,$__4,$__6) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -800,7 +2238,7 @@ define('a1atscript/router/ComponentMapper',["../annotations", "../ng2Directives/
 });
 
 define('a1atscript/router/RouteConfig',["../ToAnnotation"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var ToAnnotation = $__0.ToAnnotation;
@@ -820,7 +2258,7 @@ define('a1atscript/router/RouteConfig',["../ToAnnotation"], function($__0) {
 });
 
 define('a1atscript/router/RouteReader',["./RouteConfig", "../AnnotationFinder"], function($__0,$__2) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -873,7 +2311,7 @@ define('a1atscript/router/RouteReader',["./RouteConfig", "../AnnotationFinder"],
 });
 
 define('a1atscript/router/RouteInitializer',[], function() {
-
+  
   var RouteInitializer = function RouteInitializer(componentMapper) {
     this.componentMapper = componentMapper;
   };
@@ -948,7 +2386,7 @@ define('a1atscript/router/RouteInitializer',[], function() {
 });
 
 define('a1atscript/Router',["./router/ComponentMapper", "./router/RouteReader", "./router/RouteInitializer", "./router/RouteConfig"], function($__0,$__2,$__4,$__6) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -981,7 +2419,7 @@ define('a1atscript/Router',["./router/ComponentMapper", "./router/RouteReader", 
 });
 
 define('a1atscript/injectorTypes',["./annotations", "./Router"], function($__0,$__2) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -1205,7 +2643,7 @@ define('a1atscript/injectorTypes',["./annotations", "./Router"], function($__0,$
 });
 
 define('a1atscript/Injector',["./annotations", "./AnnotationFinder", "./injectorTypes"], function($__0,$__2,$__4) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -1402,7 +2840,7 @@ define('a1atscript/Injector',["./annotations", "./AnnotationFinder", "./injector
 });
 
 define('a1atscript/DirectiveObject',["./injectorTypes", "./Injector", "./ToAnnotation"], function($__0,$__2,$__4) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -1481,7 +2919,7 @@ define('a1atscript/DirectiveObject',["./injectorTypes", "./Injector", "./ToAnnot
 });
 
 define('a1atscript/ng2Directives/Ng2DirectiveDefinitionObject',["./SelectorMatcher"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var SelectorMatcher = $__0.default;
@@ -1563,7 +3001,7 @@ define('a1atscript/ng2Directives/Ng2DirectiveDefinitionObject',["./SelectorMatch
 });
 
 define('a1atscript/ng2Directives/BindBuilder',[], function() {
-
+  
   var BindBuilder = function BindBuilder(bindObj, component) {
     this._bindObj = bindObj;
     this._component = component;
@@ -1586,7 +3024,7 @@ define('a1atscript/ng2Directives/BindBuilder',[], function() {
 });
 
 define('a1atscript/ng2Directives/PropertiesBuilder',["./BindBuilder"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var BindBuilder = $__0.default;
@@ -1644,7 +3082,7 @@ define('a1atscript/ng2Directives/PropertiesBuilder',["./BindBuilder"], function(
 });
 
 define('a1atscript/ng2Directives/EventsBuilder',["./BindBuilder"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var BindBuilder = $__0.default;
@@ -1667,7 +3105,7 @@ define('a1atscript/ng2Directives/EventsBuilder',["./BindBuilder"], function($__0
 });
 
 define('a1atscript/ng2Directives/ComponentInjector',["../Injector", "./Component", "../injectorTypes", "./Ng2DirectiveDefinitionObject", "./PropertiesBuilder", "./EventsBuilder", "../Router"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -1744,7 +3182,7 @@ define('a1atscript/ng2Directives/ComponentInjector',["../Injector", "./Component
 });
 
 define('a1atscript/bootstrap',["./Injector", "./Router"], function($__0,$__2) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
@@ -1766,7 +3204,7 @@ define('a1atscript/bootstrap',["./Injector", "./Router"], function($__0,$__2) {
 });
 
 define('a1atscript',["./a1atscript/Injector", "./a1atscript/annotations", "./a1atscript/DirectiveObject", "./a1atscript/ng2Directives/ComponentInjector", "./a1atscript/ng2Directives/Component", "./a1atscript/ToAnnotation", "./a1atscript/bootstrap", "./a1atscript/Router"], function($__0,$__1,$__2,$__3,$__4,$__5,$__6,$__7) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__1 || !$__1.__esModule)
@@ -1783,282 +3221,177 @@ define('a1atscript',["./a1atscript/Injector", "./a1atscript/annotations", "./a1a
     $__6 = {default: $__6};
   if (!$__7 || !$__7.__esModule)
     $__7 = {default: $__7};
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Injector_46_js__ = $__0;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__ = $__1;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_DirectiveObject_46_js__ = $__2;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Injector_46_js__ = $__0;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__ = $__1;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_DirectiveObject_46_js__ = $__2;
   $__3;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__ = $__4;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ToAnnotation_46_js__ = $__5;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_bootstrap_46_js__ = $__6;
-  var $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Router_46_js__ = $__7;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__ = $__4;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ToAnnotation_46_js__ = $__5;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_bootstrap_46_js__ = $__6;
+  var $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Router_46_js__ = $__7;
   return {
     get registerInjector() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Injector_46_js__.registerInjector;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Injector_46_js__.registerInjector;
     },
     get getInjector() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Injector_46_js__.getInjector;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Injector_46_js__.getInjector;
     },
     get Injector() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Injector_46_js__.Injector;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Injector_46_js__.Injector;
     },
     get Config() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Config;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Config;
     },
     get Run() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Run;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Run;
     },
     get Controller() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Controller;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Controller;
     },
     get Directive() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Directive;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Directive;
     },
     get Service() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Service;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Service;
     },
     get Factory() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Factory;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Factory;
     },
     get Provider() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Provider;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Provider;
     },
     get Value() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Value;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Value;
     },
     get Constant() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Constant;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Constant;
     },
     get Filter() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Filter;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Filter;
     },
     get Animation() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Animation;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Animation;
     },
     get Module() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.Module;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.Module;
     },
     get AsModule() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_annotations_46_js__.AsModule;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_annotations_46_js__.AsModule;
     },
     get DirectiveObject() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_DirectiveObject_46_js__.DirectiveObject;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_DirectiveObject_46_js__.DirectiveObject;
     },
     get Component() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.Component;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.Component;
     },
     get Template() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.Template;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.Template;
     },
     get View() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.View;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ng2Directives_47_Component_46_js__.View;
     },
     get ToAnnotation() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_ToAnnotation_46_js__.ToAnnotation;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_ToAnnotation_46_js__.ToAnnotation;
     },
     get bootstrap() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_bootstrap_46_js__.bootstrap;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_bootstrap_46_js__.bootstrap;
     },
     get Router() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Router_46_js__.Router;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Router_46_js__.Router;
     },
     get RouteConfig() {
-      return $___46__46__47_node_95_modules_47_a1atscript_47_dist_47_a1atscript_46_js_47_Router_46_js__.RouteConfig;
+      return $___46__46__47_node_95_modules_47_a1atscript_47_src_47_a1atscript_46_js_47_Router_46_js__.RouteConfig;
     },
     __esModule: true
   };
 });
 
-define('relayer/SimpleFactoryInjector',["a1atscript"], function($__0) {
-
+define('xing-inflector',["a1atscript"], function($__0) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var $__1 = $__0,
-      registerInjector = $__1.registerInjector,
-      ToAnnotation = $__1.ToAnnotation;
-  var SimpleFactory = function SimpleFactory(token) {
-    var dependencies = arguments[1] !== (void 0) ? arguments[1] : [];
-    this.token = token;
-    this.dependencies = dependencies;
-  };
-  ($traceurRuntime.createClass)(SimpleFactory, {}, {});
-  Object.defineProperty(SimpleFactory, "annotations", {get: function() {
-      return [new ToAnnotation];
-    }});
-  var SimpleFactoryInjector = function SimpleFactoryInjector() {
+      AsModule = $__1.AsModule,
+      Service = $__1.Service;
+  var Inflector = function Inflector() {
     ;
   };
-  ($traceurRuntime.createClass)(SimpleFactoryInjector, {
-    get annotationClass() {
-      return SimpleFactory;
+  ($traceurRuntime.createClass)(Inflector, {
+    camelize: function(key) {
+      if (!angular.isString(key)) {
+        return key;
+      }
+      return key.replace(/_[\w\d]/g, function(match, index, string) {
+        return index === 0 ? match : string.charAt(index + 1).toUpperCase();
+      });
     },
-    instantiate: function(module, dependencyList) {
+    humanize: function(key) {
+      if (!angular.isString(key)) {
+        return key;
+      }
+      return key.replace(/_/g, ' ').replace(/(\w+)/g, function(match) {
+        return match.charAt(0).toUpperCase() + match.slice(1);
+      });
+    },
+    underscore: function(key) {
+      if (!angular.isString(key)) {
+        return key;
+      }
+      return key.replace(/[A-Z]/g, function(match, index) {
+        return index === 0 ? match : '_' + match.toLowerCase();
+      });
+    },
+    dasherize: function(key) {
+      if (!angular.isString(key)) {
+        return key;
+      }
+      return key.replace(/[A-Z]/g, function(match, index) {
+        return index === 0 ? match : '-' + match.toLowerCase();
+      });
+    },
+    pluralize: function(value) {
+      return value + 's';
+    }
+  }, {});
+  var $__default = Inflector;
+  Object.defineProperty(Inflector, "annotations", {get: function() {
+      return [new AsModule('inflector'), new Service('Inflector')];
+    }});
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/EmbeddedRelationshipTransformer',["./ResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var ResourceTransformer = $__0.default;
+  var EmbeddedRelationshipTransformer = function EmbeddedRelationshipTransformer(relationshipName) {
+    $traceurRuntime.superConstructor($EmbeddedRelationshipTransformer).call(this);
+    this.relationshipName = relationshipName;
+  };
+  var $EmbeddedRelationshipTransformer = EmbeddedRelationshipTransformer;
+  ($traceurRuntime.createClass)(EmbeddedRelationshipTransformer, {
+    transformRequest: function(endpoint, value) {
+      var resource = endpoint.resource;
+      resource.relationships[this.relationshipName] = value;
+      return resource;
+    },
+    transformResponse: function(endpoint, response) {
       var $__2 = this;
-      dependencyList.forEach((function(dependencyObject) {
-        $__2.instantiateOne(module, dependencyObject.dependency, dependencyObject.metadata);
+      return response.then((function(resource) {
+        endpoint.resource = resource;
+        return resource.relationships[$__2.relationshipName];
+      })).catch((function(error) {
+        throw error.relationships[$__2.relationshipName];
       }));
-    },
-    instantiateOne: function(module, FactoryClass, metadata) {
-      var injector = this;
-      var factory = function() {
-        for (var passedDependencies = [],
-            $__4 = 0; $__4 < arguments.length; $__4++)
-          passedDependencies[$__4] = arguments[$__4];
-        return function() {
-          for (var args = [],
-              $__5 = 0; $__5 < arguments.length; $__5++)
-            args[$__5] = arguments[$__5];
-          var newArgs = passedDependencies.concat(args);
-          var builtObject = new (Function.prototype.bind.apply(FactoryClass, $traceurRuntime.spread([null], newArgs)))();
-          return builtObject;
-        };
-      };
-      factory['$inject'] = metadata.dependencies;
-      module.factory(metadata.token, factory);
     }
-  }, {});
-  registerInjector('simpleFactory', SimpleFactoryInjector);
-  return {
-    get SimpleFactory() {
-      return SimpleFactory;
-    },
-    get SimpleFactoryInjector() {
-      return SimpleFactoryInjector;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/DataWrapper',["./jsonpath", "./SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var jsonPath = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var DataWrapper = function DataWrapper(response) {
-    this._response = response;
-  };
-  ($traceurRuntime.createClass)(DataWrapper, {
-    pathBuild: function(path, value) {
-      var segments = path.split(".");
-      var root = segments.shift();
-      if (root !== "$") {
-        console.log(("root of path " + path + " was " + root + ", not \"$\""));
-        return false;
-      }
-      var target = segments.pop();
-      var thumb = this._response;
-      segments.forEach((function(segment) {
-        if (segment === '') {
-          return ;
-        }
-        if (!thumb[segment]) {
-          thumb[segment] = {};
-        }
-        thumb = thumb[segment];
-      }));
-      thumb[target] = value;
-    },
-    pathGet: function(path) {
-      var temp = jsonPath(this._response, path, {
-        flatten: false,
-        wrap: true
-      });
-      if (temp.length === 0) {
-        return undefined;
-      } else {
-        return temp[0];
-      }
-    },
-    pathSet: function(jsonpath, value) {
-      var path = jsonPath(this._response, jsonpath, {
-        wrap: true,
-        resultType: "path"
-      });
-      if (path && path.length > 0) {
-        path = path[0];
-        if (path[0] !== "$") {
-          console.log(("Warning! root of normalized path '" + path + "' was '" + path[0] + "', not '$'"));
-        }
-        var root = path.shift();
-        var target = path.pop();
-        var thumb = this._response;
-        var $__8 = true;
-        var $__9 = false;
-        var $__10 = undefined;
-        try {
-          for (var $__6 = void 0,
-              $__5 = (path)[$traceurRuntime.toProperty(Symbol.iterator)](); !($__8 = ($__6 = $__5.next()).done); $__8 = true) {
-            var segment = $__6.value;
-            {
-              thumb = thumb[segment];
-            }
-          }
-        } catch ($__11) {
-          $__9 = true;
-          $__10 = $__11;
-        } finally {
-          try {
-            if (!$__8 && $__5.return != null) {
-              $__5.return();
-            }
-          } finally {
-            if ($__9) {
-              throw $__10;
-            }
-          }
-        }
-        if (thumb[target] != value) {
-          this._dirty = true;
-        }
-        thumb[target] = value;
-      } else {}
-    },
-    pathClear: function(jsonpath) {
-      var path = jsonPath(this._response, jsonpath, {
-        wrap: true,
-        resultType: "path"
-      });
-      if (path && path.length === 0) {
-        return ;
-      }
-      path = path[0];
-      if (path[0] !== "$") {
-        console.log(("root of normalized path was '" + path[0] + "', not '$'"));
-      }
-      var root = path.shift();
-      var target = path.pop();
-      var thumb = this._response;
-      var $__8 = true;
-      var $__9 = false;
-      var $__10 = undefined;
-      try {
-        for (var $__6 = void 0,
-            $__5 = (path)[$traceurRuntime.toProperty(Symbol.iterator)](); !($__8 = ($__6 = $__5.next()).done); $__8 = true) {
-          var segment = $__6.value;
-          {
-            thumb = thumb[segment];
-          }
-        }
-      } catch ($__11) {
-        $__9 = true;
-        $__10 = $__11;
-      } finally {
-        try {
-          if (!$__8 && $__5.return != null) {
-            $__5.return();
-          }
-        } finally {
-          if ($__9) {
-            throw $__10;
-          }
-        }
-      }
-      delete thumb[target];
-    }
-  }, {});
-  var $__default = DataWrapper;
+  }, {}, ResourceTransformer);
+  var $__default = EmbeddedRelationshipTransformer;
   return {
     get default() {
       return $__default;
@@ -2067,184 +3400,329 @@ define('relayer/DataWrapper',["./jsonpath", "./SimpleFactoryInjector"], function
   };
 });
 
-define('relayer/APIError',["./DataWrapper"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var DataWrapper = $__0.default;
-  var APIError = function APIError(responseData) {
-    var $__2;
-    $traceurRuntime.superConstructor($APIError).call(this);
-    this._response = responseData;
-    this.unhandled = [];
-    if (this.constructor.properties) {
-      this.unhandled = Object.keys(this.constructor.properties).filter(($__2 = this, function(name) {
-        return $__2[name] && $__2[name].message;
-      })).map((function(name) {
-        return name;
-      }));
-    }
-  };
-  var $APIError = APIError;
-  ($traceurRuntime.createClass)(APIError, {handleMessage: function(attrName) {
-      if (this[attrName]) {
-        this.unhandled = this.unhandled.filter((function(name) {
-          return name != attrName;
-        }));
-        return this[attrName].message;
-      }
-    }}, {}, DataWrapper);
-  var $__default = APIError;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/ResourceDescription',["./APIError", "a1atscript", "./SimpleFactoryInjector"], function($__0,$__2,$__4) {
-
+define('relayer/relationshipDescriptions/SingleRelationshipDescription',["./RelationshipDescription", "../initializers/SingleRelationshipInitializer", "../mappers/ResourceMapper", "../serializers/ResourceSerializer", "xing-inflector", "../transformers/PrimaryResourceTransformer", "../transformers/EmbeddedRelationshipTransformer", "../endpoints/ResolvedEndpoint", "../endpoints/LoadedDataEndpoint", "../TemplatedUrl", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16,$__18,$__20) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
   if (!$__4 || !$__4.__esModule)
     $__4 = {default: $__4};
-  var APIError = $__0.default;
-  var Service = $__2.Service;
-  var SimpleFactory = $__4.SimpleFactory;
-  var resourcesToInitialize = [];
-  function describeResource(resourceClass, defineFn) {
-    resourcesToInitialize.push({
-      resourceClass: resourceClass,
-      defineFn: defineFn
-    });
-  }
-  var InitializedResourceClasses = function InitializedResourceClasses(resourceDescriptionFactory) {
-    this.resourceDescriptionFactory = resourceDescriptionFactory;
-    this.initializeClasses();
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
+  if (!$__18 || !$__18.__esModule)
+    $__18 = {default: $__18};
+  if (!$__20 || !$__20.__esModule)
+    $__20 = {default: $__20};
+  var RelationshipDescription = $__0.default;
+  var SingleRelationshipInitializer = $__2.default;
+  var ResourceMapper = $__4.default;
+  var ResourceSerializer = $__6.default;
+  var Inflector = $__8.default;
+  var PrimaryResourceTransformer = $__10.default;
+  var EmbeddedRelationshipTransformer = $__12.default;
+  var ResolvedEndpoint = $__14.default;
+  var LoadedDataEndpoint = $__16.default;
+  var TemplatedUrl = $__18.TemplatedUrl;
+  var $__21 = $__20,
+      Inject = $__21.Inject,
+      factory = $__21.factory;
+  var SingleRelationshipDescription = function SingleRelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, primaryResourceTransformerFactory, embeddedRelationshipTransformerFactory, resolvedEndpointFactory, loadedDataEndpointFactory, templatedUrlFactory, name, ResourceClass, initialValues) {
+    $traceurRuntime.superConstructor($SingleRelationshipDescription).call(this, relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues);
+    this.primaryResourceTransformerFactory = primaryResourceTransformerFactory;
+    this.embeddedRelationshipTransformerFactory = embeddedRelationshipTransformerFactory;
+    this.resolvedEndpointFactory = resolvedEndpointFactory;
+    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
+    this.templatedUrlFactory = templatedUrlFactory;
+    this._templated = false;
   };
-  ($traceurRuntime.createClass)(InitializedResourceClasses, {initializeClasses: function() {
-      var $__6 = this;
-      resourcesToInitialize.forEach((function(resourceToInitialize) {
-        var resourceClass = resourceToInitialize.resourceClass;
-        var defineFn = resourceToInitialize.defineFn;
-        var resourceDescription = resourceClass.description($__6.resourceDescriptionFactory);
-        defineFn(resourceDescription);
-      }));
-      return resourcesToInitialize.map((function(resourceToInitialize) {
-        var resourceClass = resourceToInitialize.resourceClass;
-        var resourceDescription = resourceClass.resourceDescription;
-        var errorClass = function(responseData) {
-          APIError.call(this, responseData);
-        };
-        errorClass.relationships = {};
-        errorClass.properties = {};
-        errorClass.prototype = Object.create(APIError.prototype);
-        errorClass.prototype.constructor = errorClass;
-        resourceDescription.applyToResource(resourceClass.prototype);
-        resourceDescription.applyToError(errorClass.prototype);
-        resourceClass.errorClass = errorClass;
-        return resourceClass;
-      }));
-    }}, {});
-  Object.defineProperty(InitializedResourceClasses, "annotations", {get: function() {
-      return [new Service('InitializedResourceClasses', ['ResourceDescriptionFactory'])];
-    }});
-  var ResourceDescription = function ResourceDescription(jsonPropertyDecoratorFactory, relatedResourceDecoratorFactory, singleRelationshipDescriptionFactory, manyRelationshipDescriptionFactory, listRelationshipDescriptionFactory, mapRelationshipDescriptionFactory, inflector) {
-    this.jsonPropertyDecoratorFactory = jsonPropertyDecoratorFactory;
-    this.relatedResourceDecoratorFactory = relatedResourceDecoratorFactory;
-    this.singleRelationshipDescriptionFactory = singleRelationshipDescriptionFactory;
-    this.manyRelationshipDescriptionFactory = manyRelationshipDescriptionFactory;
-    this.listRelationshipDescriptionFactory = listRelationshipDescriptionFactory;
-    this.mapRelationshipDescriptionFactory = mapRelationshipDescriptionFactory;
-    this.inflector = inflector;
-    this.decorators = {};
-    this.allDecorators = [];
-    this.parentDescription = null;
-  };
-  ($traceurRuntime.createClass)(ResourceDescription, {
-    chainFrom: function(other) {
-      if (this.parentDescription && this.parentDescription !== other) {
-        throw new Error("Attempted to rechain description: existing parent if of " + (this.parentDescription.ResourceClass + ", new is of " + other.ResourceClass));
-      } else {
-        this.parentDescription = other;
+  var $SingleRelationshipDescription = SingleRelationshipDescription;
+  ($traceurRuntime.createClass)(SingleRelationshipDescription, {
+    set templated(templated) {
+      this._templated = templated;
+    },
+    get templated() {
+      return this._templated;
+    },
+    embeddedEndpoint: function(parent, uriParams) {
+      if (this._templated) {
+        throw "A templated hasOne relationship cannot be embedded";
       }
+      var parentEndpoint = parent.self();
+      var embeddedRelationshipTransformer = this.embeddedRelationshipTransformerFactory(this.name);
+      return this.loadedDataEndpointFactory(parentEndpoint, parent, embeddedRelationshipTransformer);
     },
-    recordDecorator: function(name, decoratorDescription) {
-      this.decorators[name] = this.decorators[name] || [];
-      this.decorators[name].push(decoratorDescription);
-      this.allDecorators.push(decoratorDescription);
-      return decoratorDescription;
-    },
-    applyToResource: function(resource) {
-      this.allDecorators.forEach((function(decorator) {
-        decorator.resourceApply(resource);
-      }));
-      if (this.parentDescription) {
-        this.parentDescription.applyToResource(resource);
+    linkedEndpoint: function(parent, uriParams) {
+      var transport = parent.self().transport;
+      var url = parent.pathGet(this.linksPath);
+      var params = this._templated ? uriParams : {};
+      var templatedUrl = this.templatedUrlFactory(url, params);
+      if (!this._templated) {
+        templatedUrl.addDataPathLink(parent, this.linksPath);
       }
-    },
-    applyToError: function(error) {
-      this.allDecorators.forEach((function(decorator) {
-        decorator.errorsApply(error);
-      }));
-      if (this.parentDescription) {
-        this.parentDescription.applyToError(error);
-      }
-    },
-    applyToEndpoint: function(endpoint) {
-      this.allDecorators.forEach((function(decorator) {
-        decorator.endpointApply(endpoint);
-      }));
-      if (this.parentDescription) {
-        this.parentDescription.applyToEndpoint(endpoint);
-      }
-    },
-    property: function(property, initial) {
-      this.jsonProperty(property, ("$.data." + this.inflector.underscore(property)), initial);
-    },
-    hasOne: function(property, rezClass, initialValues) {
-      return this.relatedResource(property, rezClass, initialValues, this.singleRelationshipDescriptionFactory);
-    },
-    hasMany: function(property, rezClass, initialValues) {
-      return this.relatedResource(property, rezClass, initialValues, this.manyRelationshipDescriptionFactory);
-    },
-    hasList: function(property, rezClass, initialValues) {
-      return this.relatedResource(property, rezClass, initialValues, this.listRelationshipDescriptionFactory);
-    },
-    hasMap: function(property, rezClass, initialValue) {
-      return this.relatedResource(property, rezClass, initialValue, this.mapRelationshipDescriptionFactory);
-    },
-    jsonProperty: function(name, path, value, options) {
-      return this.recordDecorator(name, this.jsonPropertyDecoratorFactory(name, path, value, options));
-    },
-    relatedResource: function(property, rezClass, initialValues, relationshipDescriptionFactory) {
-      var relationship = relationshipDescriptionFactory(property, rezClass, initialValues);
-      this.recordDecorator(name, this.relatedResourceDecoratorFactory(property, relationship));
-      return relationship;
+      var primaryResourceTransformer = this.primaryResourceTransformerFactory(this);
+      return this.resolvedEndpointFactory(transport, templatedUrl, primaryResourceTransformer);
     }
-  }, {});
-  Object.defineProperty(ResourceDescription, "annotations", {get: function() {
-      return [new SimpleFactory('ResourceDescriptionFactory', ['JsonPropertyDecoratorFactory', 'RelatedResourceDecoratorFactory', 'SingleRelationshipDescriptionFactory', 'ManyRelationshipDescriptionFactory', 'ListRelationshipDescriptionFactory', 'MapRelationshipDescriptionFactory', 'Inflector'])];
-    }});
+  }, {}, RelationshipDescription);
+  var $__default = SingleRelationshipDescription;
+  Inject(factory(SingleRelationshipInitializer), factory(ResourceMapper), factory(ResourceSerializer), Inflector, factory(PrimaryResourceTransformer), factory(EmbeddedRelationshipTransformer), factory(ResolvedEndpoint), factory(LoadedDataEndpoint), factory(TemplatedUrl))(SingleRelationshipDescription);
   return {
-    get describeResource() {
-      return describeResource;
+    get default() {
+      return $__default;
     },
-    get InitializedResourceClasses() {
-      return InitializedResourceClasses;
+    __esModule: true
+  };
+});
+
+define('relayer/relationshipDescriptions/MultipleRelationshipDescription',["./RelationshipDescription"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var RelationshipDescription = $__0.default;
+  var MultipleRelationshipDescription = function MultipleRelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, embeddedRelationshipTransformerFactory, singleFromManyTransformerFactory, loadedDataEndpointFactory, name, ResourceClass, initialValues) {
+    $traceurRuntime.superConstructor($MultipleRelationshipDescription).call(this, relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues);
+    this.embeddedRelationshipTransformerFactory = embeddedRelationshipTransformerFactory;
+    this.singleFromManyTransformerFactory = singleFromManyTransformerFactory;
+    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
+  };
+  var $MultipleRelationshipDescription = MultipleRelationshipDescription;
+  ($traceurRuntime.createClass)(MultipleRelationshipDescription, {
+    embeddedEndpoint: function(parent, uriParams) {
+      var parentEndpoint = parent.self();
+      var transformer;
+      if (typeof uriParams == 'string') {
+        transformer = this.singleFromManyTransformerFactory(this.name, uriParams);
+      } else {
+        transformer = this.embeddedRelationshipTransformerFactory(this.name);
+      }
+      return this.loadedDataEndpointFactory(parentEndpoint, parent, transformer);
     },
-    get ResourceDescription() {
-      return ResourceDescription;
+    linkedEndpoint: function(parent, uriParams) {
+      throw "Error: a many relationships must be embedded";
+    }
+  }, {}, RelationshipDescription);
+  var $__default = MultipleRelationshipDescription;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/initializers/ManyRelationshipInitializer',["./RelationshipInitializer", "./SingleRelationshipInitializer", "../injector"], function($__0,$__2,$__4) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var RelationshipInitializer = $__0.default;
+  var SingleRelationshipInitializer = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var ManyRelationshipInitializer = function ManyRelationshipInitializer(singleRelationshipInitializerFactory, ResourceClass, initialValues) {
+    $traceurRuntime.superConstructor($ManyRelationshipInitializer).call(this, ResourceClass, initialValues);
+    this.singleRelationshipInitializerFactory = singleRelationshipInitializerFactory;
+  };
+  var $ManyRelationshipInitializer = ManyRelationshipInitializer;
+  ($traceurRuntime.createClass)(ManyRelationshipInitializer, {initialize: function() {
+      var $__6 = this;
+      var relationship = [];
+      var response = [];
+      if (this.initialValues) {
+        this.initialValues.forEach((function(initialValue) {
+          var singleInitializer = $__6.singleRelationshipInitializerFactory($__6.ResourceClass, initialValue);
+          var singleRelationship = singleInitializer.initialize();
+          relationship.push(singleRelationship);
+          response.push(singleRelationship.response);
+        }));
+      }
+      return relationship;
+    }}, {}, RelationshipInitializer);
+  var $__default = ManyRelationshipInitializer;
+  Inject(factory(SingleRelationshipInitializer))(ManyRelationshipInitializer);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/mappers/ManyResourceMapper',["./Mapper", "../relationshipDescriptions/SingleRelationshipDescription", "../injector"], function($__0,$__2,$__4) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var Mapper = $__0.default;
+  var SingleRelationshipDescription = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var ManyResourceMapper = function ManyResourceMapper(singleRelationshipDescriptionFactory, transport, response, relationshipDescription) {
+    var useErrors = arguments[4] !== (void 0) ? arguments[4] : false;
+    $traceurRuntime.superConstructor($ManyResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
+    this.singleRelationshipDescription = singleRelationshipDescriptionFactory("", this.ResourceClass);
+  };
+  var $ManyResourceMapper = ManyResourceMapper;
+  ($traceurRuntime.createClass)(ManyResourceMapper, {
+    initializeModel: function() {
+      this.mapped = [];
+    },
+    mapNestedRelationships: function() {
+      var $__6 = this;
+      this.response.forEach((function(response) {
+        var resourceMapper = $__6.singleRelationshipDescription.mapperFactory($__6.transport, response, $__6.singleRelationshipDescription);
+        resourceMapper.uriTemplate = $__6.uriTemplate;
+        $__6.mapped.push(resourceMapper.map());
+      }));
+    }
+  }, {}, Mapper);
+  var $__default = ManyResourceMapper;
+  Inject(factory(SingleRelationshipDescription))(ManyResourceMapper);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/serializers/ManyResourceSerializer',["./Serializer", "./ResourceSerializer", "../injector"], function($__0,$__2,$__4) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var Serializer = $__0.default;
+  var ResourceSerializer = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var ManyResourceSerializer = function ManyResourceSerializer(resourceSerializerFactory, resource) {
+    $traceurRuntime.superConstructor($ManyResourceSerializer).call(this, resource);
+    this.resourceSerializerFactory = resourceSerializerFactory;
+  };
+  var $ManyResourceSerializer = ManyResourceSerializer;
+  ($traceurRuntime.createClass)(ManyResourceSerializer, {serialize: function() {
+      var $__6 = this;
+      return this.resource.map((function(resource) {
+        return $__6.resourceSerializerFactory(resource).serialize();
+      }));
+    }}, {}, Serializer);
+  var $__default = ManyResourceSerializer;
+  Inject(factory(ResourceSerializer))(ManyResourceSerializer);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/transformers/SingleFromManyTransformer',["./ResourceTransformer"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var ResourceTransformer = $__0.default;
+  var SingleFromManyTransformer = function SingleFromManyTransformer(relationshipName, property) {
+    $traceurRuntime.superConstructor($SingleFromManyTransformer).call(this);
+    this.property = property;
+    this.relationshipName = relationshipName;
+  };
+  var $SingleFromManyTransformer = SingleFromManyTransformer;
+  ($traceurRuntime.createClass)(SingleFromManyTransformer, {
+    transformRequest: function(endpoint, value) {
+      var resource = endpoint.resource;
+      resource.relationships[this.relationshipName][this.property] = value;
+      return resource;
+    },
+    transformResponse: function(endpoint, response) {
+      var $__2 = this;
+      return response.then((function(resource) {
+        endpoint.resource = resource;
+        return resource.relationships[$__2.relationshipName][$__2.property];
+      })).catch((function(error) {
+        throw error.relationships[$__2.relationshipName][$__2.property];
+      }));
+    }
+  }, {}, ResourceTransformer);
+  var $__default = SingleFromManyTransformer;
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/relationshipDescriptions/ManyRelationshipDescription',["./MultipleRelationshipDescription", "../initializers/ManyRelationshipInitializer", "../mappers/ManyResourceMapper", "../serializers/ManyResourceSerializer", "xing-inflector", "../transformers/EmbeddedRelationshipTransformer", "../transformers/SingleFromManyTransformer", "../endpoints/LoadedDataEndpoint", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
+  var MultipleRelationshipDescription = $__0.default;
+  var ManyRelationshipInitializer = $__2.default;
+  var ManyResourceMapper = $__4.default;
+  var ManyResourceSerializer = $__6.default;
+  var Inflector = $__8.default;
+  var EmbeddedRelationshipTransformer = $__10.default;
+  var SingleFromManyTransformer = $__12.default;
+  var LoadedDataEndpoint = $__14.default;
+  var $__17 = $__16,
+      Inject = $__17.Inject,
+      factory = $__17.factory;
+  var ManyRelationshipDescription = function ManyRelationshipDescription() {
+    $traceurRuntime.superConstructor($ManyRelationshipDescription).apply(this, arguments);
+    ;
+  };
+  var $ManyRelationshipDescription = ManyRelationshipDescription;
+  ($traceurRuntime.createClass)(ManyRelationshipDescription, {}, {}, MultipleRelationshipDescription);
+  var $__default = ManyRelationshipDescription;
+  Inject(factory(ManyRelationshipInitializer), factory(ManyResourceMapper), factory(ManyResourceSerializer), Inflector, factory(EmbeddedRelationshipTransformer), factory(SingleFromManyTransformer), factory(LoadedDataEndpoint))(ManyRelationshipDescription);
+  return {
+    get default() {
+      return $__default;
     },
     __esModule: true
   };
 });
 
 define('relayer/Resource',["./DataWrapper"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var DataWrapper = $__0.default;
@@ -2394,57 +3872,18 @@ define('relayer/Resource',["./DataWrapper"], function($__0) {
   };
 });
 
-define('relayer/endpoints/Endpoint',[], function() {
-
-  var Endpoint = function Endpoint() {};
-  ($traceurRuntime.createClass)(Endpoint, {
-    create: function(resource, res, rej) {
-      return this.endpointPromise().then((function(endpoint) {
-        if (endpoint._create) {
-          return endpoint._create(resource);
-        } else {
-          return endpoint.create(resource);
-        }
-      })).then(res, rej);
-    },
-    update: function(resource, res, rej) {
-      return this.endpointPromise().then((function(endpoint) {
-        if (endpoint._update) {
-          return endpoint._update(resource);
-        } else {
-          return endpoint.update(resource);
-        }
-      })).then(res, rej);
-    },
-    load: function(res, rej) {
-      return this.endpointPromise().then((function(endpoint) {
-        if (endpoint._load) {
-          return endpoint._load();
-        } else {
-          return endpoint.load();
-        }
-      })).then(res, rej);
-    },
-    get: function(prop) {
-      for (var args = [],
-          $__1 = 1; $__1 < arguments.length; $__1++)
-        args[$__1 - 1] = arguments[$__1];
-      return this.load().then((function(response) {
-        var $__2;
-        if (typeof response[prop] == 'function') {
-          return ($__2 = response)[prop].apply($__2, $traceurRuntime.spread(args));
-        } else {
-          return response[prop];
-        }
-      }));
-    },
-    remove: function(res, rej) {
-      return this.endpointPromise().then((function(endpoint) {
-        return endpoint._remove();
-      })).then(res, rej);
-    }
-  }, {});
-  var $__default = Endpoint;
+define('relayer/ListResource',["./Resource"], function($__0) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  var Resource = $__0.default;
+  var ListResource = function ListResource() {
+    $traceurRuntime.superConstructor($ListResource).apply(this, arguments);
+    ;
+  };
+  var $ListResource = ListResource;
+  ($traceurRuntime.createClass)(ListResource, {}, {}, Resource);
+  var $__default = ListResource;
   return {
     get default() {
       return $__default;
@@ -2453,299 +3892,49 @@ define('relayer/endpoints/Endpoint',[], function() {
   };
 });
 
-define('relayer/endpoints/PromiseEndpoint',["./Endpoint", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var Endpoint = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var PromiseEndpoint = function PromiseEndpoint(promiseFunction) {
-    $traceurRuntime.superConstructor($PromiseEndpoint).call(this);
-    this.endpointPromise = promiseFunction;
-  };
-  var $PromiseEndpoint = PromiseEndpoint;
-  ($traceurRuntime.createClass)(PromiseEndpoint, {}, {}, Endpoint);
-  var $__default = PromiseEndpoint;
-  Object.defineProperty(PromiseEndpoint, "annotations", {get: function() {
-      return [new SimpleFactory('PromiseEndpointFactory')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/endpoints/ResolvedEndpoint',["./Endpoint", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var Endpoint = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ResolvedEndpoint = function ResolvedEndpoint(Promise, transport, templatedUrl) {
-    var resourceTransformers = arguments[3] !== (void 0) ? arguments[3] : [];
-    var createResourceTransformers = arguments[4] !== (void 0) ? arguments[4] : [];
-    var $__4;
-    $traceurRuntime.superConstructor($ResolvedEndpoint).call(this);
-    this.transport = transport;
-    this.templatedUrl = templatedUrl;
-    if (Array.isArray(resourceTransformers)) {
-      this.resourceTransformers = resourceTransformers;
-    } else {
-      this.resourceTransformers = [resourceTransformers];
-    }
-    if (Array.isArray(createResourceTransformers)) {
-      this.createResourceTransformers = createResourceTransformers;
-    } else {
-      this.createResourceTransformers = [createResourceTransformers];
-    }
-    this.endpointPromise = ($__4 = this, function() {
-      return Promise.resolve($__4);
-    });
-  };
-  var $ResolvedEndpoint = ResolvedEndpoint;
-  ($traceurRuntime.createClass)(ResolvedEndpoint, {
-    _load: function() {
-      var response = this.transport.get(this.templatedUrl.url, this.templatedUrl.etag);
-      return this._transformResponse(this.resourceTransformers, response);
-    },
-    _update: function(resource) {
-      var request = this._transformRequest(this.resourceTransformers, resource);
-      var response = this.transport.put(this.templatedUrl.url, request, this.templatedUrl.etag);
-      return this._transformResponse(this.resourceTransformers, response);
-    },
-    _create: function(resource) {
-      var request = this._transformRequest(this.createResourceTransformers, resource);
-      var response = this.transport.post(this.templatedUrl.url, request);
-      return this._transformResponse(this.createResourceTransformers, response);
-    },
-    _transformResponse: function(transformers, response) {
-      var $__4 = this;
-      return transformers.reduce((function(interimResponse, transformer) {
-        return transformer.transformResponse($__4, interimResponse);
-      }), response);
-    },
-    _transformRequest: function(transformers, request) {
-      var $__4 = this;
-      return transformers.slice(0).reverse().reduce((function(interimRequest, transformer) {
-        return transformer.transformRequest($__4, interimRequest);
-      }), request);
-    },
-    _remove: function() {
-      return this.transport.delete(this.templatedUrl.url);
-    }
-  }, {}, Endpoint);
-  var $__default = ResolvedEndpoint;
-  Object.defineProperty(ResolvedEndpoint, "annotations", {get: function() {
-      return [new SimpleFactory('ResolvedEndpointFactory', ["XingPromise"])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/endpoints/LoadedDataEndpoint',["./ResolvedEndpoint", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResolvedEndpoint = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var LoadedDataEndpoint = function LoadedDataEndpoint(Promise, resolvedEndpoint, resource) {
-    var resourceTransformers = arguments[3] !== (void 0) ? arguments[3] : [];
-    var createResourceTransformers = arguments[4] !== (void 0) ? arguments[4] : [];
-    $traceurRuntime.superConstructor($LoadedDataEndpoint).call(this, Promise, resolvedEndpoint.transport, resolvedEndpoint.templatedUrl, resolvedEndpoint.resourceTransformers.concat(resourceTransformers), resolvedEndpoint.createResourceTransformers.concat(createResourceTransformers));
-    this.resource = resource;
-    this.Promise = Promise;
-    this.data = resolvedEndpoint._transformRequest(resolvedEndpoint.resourceTransformers, resource);
-  };
-  var $LoadedDataEndpoint = LoadedDataEndpoint;
-  ($traceurRuntime.createClass)(LoadedDataEndpoint, {
-    _load: function() {
-      return this._transformResponse(this.resourceTransformers, this.Promise.resolve({
-        data: this.data,
-        etag: this.templatedUrl.etag
-      }));
-    },
-    _update: function(resource) {
-      var $__4 = this;
-      var request = this._transformRequest(this.resourceTransformers, resource);
-      var response = this.transport.put(this.templatedUrl.url, request);
-      response = response.then((function(data) {
-        $__4.data = data.data;
-        return data;
-      }));
-      return this._transformResponse(this.resourceTransformers, response);
-    }
-  }, {}, ResolvedEndpoint);
-  var $__default = LoadedDataEndpoint;
-  Object.defineProperty(LoadedDataEndpoint, "annotations", {get: function() {
-      return [new SimpleFactory('LoadedDataEndpointFactory', ['XingPromise'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/endpoints',["./endpoints/PromiseEndpoint", "./endpoints/ResolvedEndpoint", "./endpoints/LoadedDataEndpoint"], function($__0,$__1,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var $__endpoints_47_PromiseEndpoint_46_js__ = $__0;
-  var $__endpoints_47_ResolvedEndpoint_46_js__ = $__1;
-  var $__endpoints_47_LoadedDataEndpoint_46_js__ = $__2;
-  return {
-    get PromiseEndpoint() {
-      return $__endpoints_47_PromiseEndpoint_46_js__.default;
-    },
-    get ResolvedEndpoint() {
-      return $__endpoints_47_ResolvedEndpoint_46_js__.default;
-    },
-    get LoadedDataEndpoint() {
-      return $__endpoints_47_LoadedDataEndpoint_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/serializers/Serializer',[], function() {
-
-  var Serializer = function Serializer(resource) {
-    this.resource = resource;
-  };
-  ($traceurRuntime.createClass)(Serializer, {serialize: function() {}}, {});
-  var $__default = Serializer;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/TemplatedUrl',["./SimpleFactoryInjector"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var SimpleFactory = $__0.SimpleFactory;
-  var TemplatedUrl = function TemplatedUrl(uriTemplate) {
-    var uriParams = arguments[1] !== (void 0) ? arguments[1] : {};
-    this._uriTemplate = new UriTemplate(uriTemplate);
-    this._uriParams = uriParams;
-    this._paths = [];
-    this._url = this._uriTemplate.fillFromObject(this._uriParams);
-  };
-  ($traceurRuntime.createClass)(TemplatedUrl, {
-    get uriTemplate() {
-      return this._uriTemplate.toString();
-    },
-    get uriParams() {
-      return this._uriParams;
-    },
-    get url() {
-      return this._url;
-    },
-    _setUrl: function(url) {
-      var uriParams = this._uriTemplate.fromUri(url);
-      this._uriParams = uriParams;
-      this._url = url;
-    },
-    addDataPathLink: function(resource, path) {
-      var overwrite = arguments[2] !== (void 0) ? arguments[2] : true;
-      if (overwrite) {
-        var newUrl = resource.pathGet(path);
-        if (newUrl) {
-          this._setUrl(newUrl);
-          this._paths.forEach((function(path) {
-            path.resource.pathSet(path.path, newUrl);
-          }));
-        }
-      } else {
-        resource.pathSet(path, this.url);
-      }
-      this._paths.push({
-        resource: resource,
-        path: path
-      });
-    },
-    removeDataPathLink: function(resource, path) {
-      this._paths = this._paths.filter((function(pathLink) {
-        return (pathLink.resource != resource) || (pathLink.path != path);
-      }));
-    }
-  }, {});
-  Object.defineProperty(TemplatedUrl, "annotations", {get: function() {
-      return [new SimpleFactory('TemplatedUrlFactory')];
-    }});
-  var TemplatedUrlFromUrl = function TemplatedUrlFromUrl(uriTemplate, url) {
-    $traceurRuntime.superConstructor($TemplatedUrlFromUrl).call(this, uriTemplate);
-    $traceurRuntime.superGet(this, $TemplatedUrlFromUrl.prototype, "_setUrl").call(this, url);
-  };
-  var $TemplatedUrlFromUrl = TemplatedUrlFromUrl;
-  ($traceurRuntime.createClass)(TemplatedUrlFromUrl, {}, {}, TemplatedUrl);
-  Object.defineProperty(TemplatedUrlFromUrl, "annotations", {get: function() {
-      return [new SimpleFactory('TemplatedUrlFromUrlFactory')];
-    }});
-  return {
-    get TemplatedUrl() {
-      return TemplatedUrl;
-    },
-    get TemplatedUrlFromUrl() {
-      return TemplatedUrlFromUrl;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/serializers/ResourceSerializer',["./Serializer", "../SimpleFactoryInjector", "../TemplatedUrl"], function($__0,$__2,$__4) {
-
+define('relayer/initializers/ListRelationshipInitializer',["./RelationshipInitializer", "../ListResource", "./ManyRelationshipInitializer", "../injector"], function($__0,$__2,$__4,$__6) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
   if (!$__4 || !$__4.__esModule)
     $__4 = {default: $__4};
-  var Serializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var TemplatedUrl = $__4.TemplatedUrl;
-  var ResourceSerializer = function ResourceSerializer() {
-    $traceurRuntime.superConstructor($ResourceSerializer).apply(this, arguments);
-    ;
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  var RelationshipInitializer = $__0.default;
+  var ListResource = $__2.default;
+  var ManyRelationshipInitializer = $__4.default;
+  var $__7 = $__6,
+      Inject = $__7.Inject,
+      factory = $__7.factory,
+      value = $__7.value;
+  var ListRelationshipInitializer = function ListRelationshipInitializer(ListResource, manyRelationshipInitializerFactory, ResourceClass, initialValues) {
+    $traceurRuntime.superConstructor($ListRelationshipInitializer).call(this, ResourceClass, initialValues);
+    this.manyRelationshipInitializer = manyRelationshipInitializerFactory(ResourceClass, initialValues);
+    this.ListResource = ListResource;
   };
-  var $ResourceSerializer = ResourceSerializer;
-  ($traceurRuntime.createClass)(ResourceSerializer, {serialize: function() {
-      var $__6 = this;
-      var relationship;
-      Object.keys(this.resource.relationships).forEach((function(relationshipName) {
-        var relationship = $__6.resource.relationships[relationshipName];
-        if (!(relationship instanceof TemplatedUrl)) {
-          var relationshipDefinition = $__6.resource.constructor.relationships[relationshipName];
-          var serializer = relationshipDefinition.serializerFactory(relationship);
-          $__6.resource.pathSet(relationshipDefinition.dataPath, serializer.serialize());
-        }
+  var $ListRelationshipInitializer = ListRelationshipInitializer;
+  ($traceurRuntime.createClass)(ListRelationshipInitializer, {initialize: function() {
+      var manyRelationships = this.manyRelationshipInitializer.initialize();
+      var resource = new this.ListResource({
+        data: manyRelationships.response,
+        links: {}
+      });
+      manyRelationships.resource = resource;
+      ["url", "uriTemplate", "uriParams", "create", "remove", "update", "load"].forEach((function(func) {
+        manyRelationships[func] = function() {
+          var $__10;
+          for (var args = [],
+              $__9 = 0; $__9 < arguments.length; $__9++)
+            args[$__9] = arguments[$__9];
+          return ($__10 = resource)[func].apply($__10, $traceurRuntime.spread(args));
+        };
       }));
-      return this.resource.response;
-    }}, {}, Serializer);
-  var $__default = ResourceSerializer;
-  Object.defineProperty(ResourceSerializer, "annotations", {get: function() {
-      return [new SimpleFactory('ResourceSerializerFactory', [])];
-    }});
+      return manyRelationships;
+    }}, {}, RelationshipInitializer);
+  var $__default = ListRelationshipInitializer;
+  Inject(value(ListResource), factory(ManyRelationshipInitializer))(ListRelationshipInitializer);
   return {
     get default() {
       return $__default;
@@ -2754,160 +3943,31 @@ define('relayer/serializers/ResourceSerializer',["./Serializer", "../SimpleFacto
   };
 });
 
-define('relayer/serializers/ManyResourceSerializer',["./Serializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
+define('relayer/TemporaryTemplatedUrl',["./TemplatedUrl"], function($__0) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var Serializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ManyResourceSerializer = function ManyResourceSerializer(resourceSerializerFactory, resource) {
-    $traceurRuntime.superConstructor($ManyResourceSerializer).call(this, resource);
-    this.resourceSerializerFactory = resourceSerializerFactory;
+  var TemplatedUrl = $__0.TemplatedUrl;
+  var TemporaryTemplatedUrl = function TemporaryTemplatedUrl(uriTemplate) {
+    $traceurRuntime.superConstructor($TemporaryTemplatedUrl).call(this, uriTemplate);
+    var url = this._uriTemplate.fill((function(varName) {
+      return ("relayer-" + $TemporaryTemplatedUrl.index);
+    }));
+    $TemporaryTemplatedUrl.index += 1;
+    this._setUrl(url);
   };
-  var $ManyResourceSerializer = ManyResourceSerializer;
-  ($traceurRuntime.createClass)(ManyResourceSerializer, {serialize: function() {
-      var $__4 = this;
-      return this.resource.map((function(resource) {
-        return $__4.resourceSerializerFactory(resource).serialize();
-      }));
-    }}, {}, Serializer);
-  var $__default = ManyResourceSerializer;
-  Object.defineProperty(ManyResourceSerializer, "annotations", {get: function() {
-      return [new SimpleFactory('ManyResourceSerializerFactory', ['ResourceSerializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
+  var $TemporaryTemplatedUrl = TemporaryTemplatedUrl;
+  ($traceurRuntime.createClass)(TemporaryTemplatedUrl, {}, {
+    get index() {
+      this._index = this._index || 1;
+      return this._index;
     },
-    __esModule: true
-  };
-});
-
-define('relayer/serializers/ListResourceSerializer',["../SimpleFactoryInjector", "./Serializer"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var SimpleFactory = $__0.SimpleFactory;
-  var Serializer = $__2.default;
-  var ListResourceSerializer = function ListResourceSerializer(manyResourceSerializerFactory, resource) {
-    $traceurRuntime.superConstructor($ListResourceSerializer).call(this, resource);
-    this.manyResourceSerializerFactory = manyResourceSerializerFactory;
-  };
-  var $ListResourceSerializer = ListResourceSerializer;
-  ($traceurRuntime.createClass)(ListResourceSerializer, {serialize: function() {
-      var data = this.manyResourceSerializerFactory(this.resource).serialize();
-      this.resource.resource.pathSet("$.data", data);
-      return this.resource.resource.response;
-    }}, {}, Serializer);
-  var $__default = ListResourceSerializer;
-  Object.defineProperty(ListResourceSerializer, "annotations", {get: function() {
-      return [new SimpleFactory('ListResourceSerializerFactory', ['ManyResourceSerializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/serializers/MapResourceSerializer',["./Serializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var Serializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var MapResourceSerializer = function MapResourceSerializer(resourceSerializerFactory, resource) {
-    $traceurRuntime.superConstructor($MapResourceSerializer).call(this, resource);
-    this.resourceSerializerFactory = resourceSerializerFactory;
-  };
-  var $MapResourceSerializer = MapResourceSerializer;
-  ($traceurRuntime.createClass)(MapResourceSerializer, {serialize: function() {
-      var $__4 = this;
-      return Object.keys(this.resource).reduce((function(data, key) {
-        data[key] = $__4.resourceSerializerFactory($__4.resource[key]).serialize();
-        return data;
-      }), {});
-    }}, {}, Serializer);
-  var $__default = MapResourceSerializer;
-  Object.defineProperty(MapResourceSerializer, "annotations", {get: function() {
-      return [new SimpleFactory('MapResourceSerializerFactory', ['ResourceSerializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/serializers',["./serializers/ResourceSerializer", "./serializers/ManyResourceSerializer", "./serializers/ListResourceSerializer", "./serializers/MapResourceSerializer"], function($__0,$__1,$__2,$__3) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__3 || !$__3.__esModule)
-    $__3 = {default: $__3};
-  var $__serializers_47_ResourceSerializer_46_js__ = $__0;
-  var $__serializers_47_ManyResourceSerializer_46_js__ = $__1;
-  var $__serializers_47_ListResourceSerializer_46_js__ = $__2;
-  var $__serializers_47_MapResourceSerializer_46_js__ = $__3;
-  return {
-    get ResourceSerializer() {
-      return $__serializers_47_ResourceSerializer_46_js__.default;
-    },
-    get ManyResourceSerializer() {
-      return $__serializers_47_ManyResourceSerializer_46_js__.default;
-    },
-    get ListResourceSerializer() {
-      return $__serializers_47_ListResourceSerializer_46_js__.default;
-    },
-    get MapResourceSerializer() {
-      return $__serializers_47_MapResourceSerializer_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/mappers/Mapper',[], function() {
-
-  var Mapper = function Mapper(transport, response, relationshipDescription) {
-    var useErrors = arguments[3] !== (void 0) ? arguments[3] : false;
-    this.transport = transport;
-    this.response = response;
-    this.relationshipDescription = relationshipDescription;
-    this.useErrors = useErrors;
-  };
-  ($traceurRuntime.createClass)(Mapper, {
-    get ResourceClass() {
-      if (this.useErrors) {
-        return this.relationshipDescription.ResourceClass.errorClass;
-      } else {
-        return this.relationshipDescription.ResourceClass;
-      }
-    },
-    get mapperFactory() {
-      return this.relationshipDescription.mapperFactory;
-    },
-    get serializerFactory() {
-      return this.relationshipDescription.serializerFactory;
-    },
-    map: function() {
-      this.initializeModel();
-      this.mapNestedRelationships();
-      return this.mapped;
+    set index(index) {
+      this._index = index;
+      return this._index;
     }
-  }, {});
-  var $__default = Mapper;
+  }, TemplatedUrl);
+  var $__default = TemporaryTemplatedUrl;
   return {
     get default() {
       return $__default;
@@ -2916,117 +3976,38 @@ define('relayer/mappers/Mapper',[], function() {
   };
 });
 
-define('relayer/mappers/ResourceMapper',["./Mapper", "../SimpleFactoryInjector"], function($__0,$__2) {
-
+define('relayer/mappers/ListResourceMapper',["./ResourceMapper", "../TemplatedUrl", "../TemporaryTemplatedUrl", "../ResourceBuilder", "../PrimaryResourceBuilder", "../transformers/PrimaryResourceTransformer", "./ManyResourceMapper", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
-  var Mapper = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ResourceMapper = function ResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, transport, response, relationshipDescription) {
-    var endpoint = arguments[7] !== (void 0) ? arguments[7] : null;
-    var useErrors = arguments[8] !== (void 0) ? arguments[8] : false;
-    $traceurRuntime.superConstructor($ResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
-    this.primaryResourceTransformerFactory = primaryResourceTransformerFactory;
-    this.templatedUrlFromUrlFactory = templatedUrlFromUrlFactory;
-    this.resourceBuilderFactory = resourceBuilderFactory;
-    this.primaryResourceBuilderFactory = primaryResourceBuilderFactory;
-    this.endpoint = endpoint;
-  };
-  var $ResourceMapper = ResourceMapper;
-  ($traceurRuntime.createClass)(ResourceMapper, {
-    initializeModel: function() {
-      if (this.endpoint) {
-        this.mapped = this.primaryResourceBuilderFactory(this.response, this.ResourceClass).build(this.endpoint);
-      } else {
-        this.mapped = this.resourceBuilderFactory(this.transport, this.response, this.primaryResourceTransformer, this.ResourceClass, this.relationshipDescription).build(this.uriTemplate);
-      }
-    },
-    get primaryResourceTransformer() {
-      this._primaryResourceTransformer = this._primaryResourceTransformer || this.primaryResourceTransformerFactory(this.relationshipDescription);
-      return this._primaryResourceTransformer;
-    },
-    mapNestedRelationships: function() {
-      var relationship;
-      this.mapped.relationships = {};
-      for (var relationshipName in this.ResourceClass.relationships) {
-        if (typeof this.ResourceClass.relationships[relationshipName] == 'object') {
-          relationship = this.ResourceClass.relationships[relationshipName];
-          if (this.mapped.pathGet(relationship.dataPath)) {
-            var subMapper = relationship.mapperFactory(this.transport, this.mapped.pathGet(relationship.dataPath), relationship, this.useErrors);
-            this.mapped.relationships[relationshipName] = subMapper.map();
-          } else if (this.mapped.pathGet(relationship.linksPath)) {
-            var templatedUrl = this.templatedUrlFromUrlFactory(this.mapped.pathGet(relationship.linksPath), this.mapped.pathGet(relationship.linksPath));
-            templatedUrl.addDataPathLink(this.mapped, relationship.linksPath);
-            this.mapped.relationships[relationshipName] = templatedUrl;
-          }
-        }
-      }
-    }
-  }, {}, Mapper);
-  var $__default = ResourceMapper;
-  Object.defineProperty(ResourceMapper, "annotations", {get: function() {
-      return [new SimpleFactory("ResourceMapperFactory", ["TemplatedUrlFromUrlFactory", "ResourceBuilderFactory", "PrimaryResourceBuilderFactory", "PrimaryResourceTransformerFactory"])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/mappers/ManyResourceMapper',["../SimpleFactoryInjector", "./Mapper"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var SimpleFactory = $__0.SimpleFactory;
-  var Mapper = $__2.default;
-  var ManyResourceMapper = function ManyResourceMapper(singleRelationshipDescriptionFactory, transport, response, relationshipDescription) {
-    var useErrors = arguments[4] !== (void 0) ? arguments[4] : false;
-    $traceurRuntime.superConstructor($ManyResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
-    this.singleRelationshipDescription = singleRelationshipDescriptionFactory("", this.ResourceClass);
-  };
-  var $ManyResourceMapper = ManyResourceMapper;
-  ($traceurRuntime.createClass)(ManyResourceMapper, {
-    initializeModel: function() {
-      this.mapped = [];
-    },
-    mapNestedRelationships: function() {
-      var $__4 = this;
-      this.response.forEach((function(response) {
-        var resourceMapper = $__4.singleRelationshipDescription.mapperFactory($__4.transport, response, $__4.singleRelationshipDescription);
-        resourceMapper.uriTemplate = $__4.uriTemplate;
-        $__4.mapped.push(resourceMapper.map());
-      }));
-    }
-  }, {}, Mapper);
-  var $__default = ManyResourceMapper;
-  Object.defineProperty(ManyResourceMapper, "annotations", {get: function() {
-      return [new SimpleFactory("ManyResourceMapperFactory", ["SingleRelationshipDescriptionFactory"])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/mappers/ListResourceMapper',["../SimpleFactoryInjector", "./ResourceMapper"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var SimpleFactory = $__0.SimpleFactory;
-  var ResourceMapper = $__2.default;
-  var ListResourceMapper = function ListResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, manyResourceMapperFactory, transport, response, relationshipDescription, endpoint) {
-    var useErrors = arguments[9] !== (void 0) ? arguments[9] : false;
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  var ResourceMapper = $__0.default;
+  var TemplatedUrlFromUrl = $__2.TemplatedUrlFromUrl;
+  var TemporaryTemplatedUrl = $__4.default;
+  var ResourceBuilder = $__6.default;
+  var PrimaryResourceBuilder = $__8.default;
+  var PrimaryResourceTransformer = $__10.default;
+  var ManyResourceMapper = $__12.default;
+  var $__15 = $__14,
+      Inject = $__15.Inject,
+      factory = $__15.factory;
+  var ListResourceMapper = function ListResourceMapper(templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, manyResourceMapperFactory, temporaryTemplatedUrlFactory, transport, response, relationshipDescription, endpoint) {
+    var useErrors = arguments[10] !== (void 0) ? arguments[10] : false;
     $traceurRuntime.superConstructor($ListResourceMapper).call(this, templatedUrlFromUrlFactory, resourceBuilderFactory, primaryResourceBuilderFactory, primaryResourceTransformerFactory, transport, response, relationshipDescription, endpoint, useErrors);
+    this.temporaryTemplatedUrlFactory = temporaryTemplatedUrlFactory;
     this.manyResourceMapperFactory = manyResourceMapperFactory;
   };
   var $ListResourceMapper = ListResourceMapper;
@@ -3038,62 +4019,67 @@ define('relayer/mappers/ListResourceMapper',["../SimpleFactoryInjector", "./Reso
       return this.relationshipDescription.ResourceClass;
     },
     mapNestedRelationships: function() {
-      var $__4 = this;
+      var $__16 = this;
       $traceurRuntime.superGet(this, $ListResourceMapper.prototype, "mapNestedRelationships").call(this);
       this.resource = this.mapped;
       var manyResourceMapper = this.manyResourceMapperFactory(this.transport, this.resource.pathGet("$.data"), this.relationshipDescription);
-      manyResourceMapper.uriTemplate = this.resource.pathGet("$.links.template");
+      var uriTemplate = this.resource.pathGet("$.links.template");
+      manyResourceMapper.uriTemplate = uriTemplate;
       this.mapped = manyResourceMapper.map();
       this.mapped.resource = this.resource;
       ["url", "uriTemplate", "uriParams"].forEach((function(func) {
-        $__4.mapped[func] = function() {
-          var $__8;
+        $__16.mapped[func] = function() {
+          var $__20;
           for (var args = [],
-              $__7 = 0; $__7 < arguments.length; $__7++)
-            args[$__7] = arguments[$__7];
-          return ($__8 = this.resource)[func].apply($__8, $traceurRuntime.spread(args));
+              $__19 = 0; $__19 < arguments.length; $__19++)
+            args[$__19] = arguments[$__19];
+          return ($__20 = this.resource)[func].apply($__20, $traceurRuntime.spread(args));
         };
       }));
       var mapped = this.mapped;
       ["remove", "update", "load"].forEach((function(func) {
-        $__4.mapped[func] = function() {
-          var $__8;
+        $__16.mapped[func] = function() {
+          var $__20;
           for (var args = [],
-              $__7 = 0; $__7 < arguments.length; $__7++)
-            args[$__7] = arguments[$__7];
-          return ($__8 = this.resource.self())[func].apply($__8, $traceurRuntime.spread([mapped], args));
+              $__19 = 0; $__19 < arguments.length; $__19++)
+            args[$__19] = arguments[$__19];
+          return ($__20 = this.resource.self())[func].apply($__20, $traceurRuntime.spread([mapped], args));
         };
       }));
       Object.keys(this.resource.relationships).forEach((function(key) {
-        $__4.mapped[key] = function() {
-          var $__8;
+        $__16.mapped[key] = function() {
+          var $__20;
           for (var args = [],
-              $__7 = 0; $__7 < arguments.length; $__7++)
-            args[$__7] = arguments[$__7];
-          return ($__8 = this.resource)[key].apply($__8, $traceurRuntime.spread(args));
+              $__19 = 0; $__19 < arguments.length; $__19++)
+            args[$__19] = arguments[$__19];
+          return ($__20 = this.resource)[key].apply($__20, $traceurRuntime.spread(args));
         };
       }));
       this.mapped.create = function() {
-        var $__8;
+        var $__20;
         for (var args = [],
-            $__7 = 0; $__7 < arguments.length; $__7++)
-          args[$__7] = arguments[$__7];
-        var $__5 = this;
-        return ($__8 = this.resource).create.apply($__8, $traceurRuntime.spread(args)).then((function(created) {
-          $__5.push(created);
+            $__19 = 0; $__19 < arguments.length; $__19++)
+          args[$__19] = arguments[$__19];
+        var $__17 = this;
+        return ($__20 = this.resource).create.apply($__20, $traceurRuntime.spread(args)).then((function(created) {
+          $__17.push(created);
           return created;
         }));
       };
       var ItemResourceClass = this.ItemResourceClass;
+      var temporaryTemplatedUrlFactory = this.temporaryTemplatedUrlFactory;
       this.mapped.new = function() {
-        return new ItemResourceClass();
+        var withUrl = arguments[0] !== (void 0) ? arguments[0] : false;
+        var item = new ItemResourceClass();
+        if (withUrl) {
+          item.templatedUrl = temporaryTemplatedUrlFactory(uriTemplate);
+        }
+        return item;
       };
     }
   }, {}, ResourceMapper);
   var $__default = ListResourceMapper;
-  Object.defineProperty(ListResourceMapper, "annotations", {get: function() {
-      return [new SimpleFactory('ListResourceMapperFactory', ['TemplatedUrlFromUrlFactory', 'ResourceBuilderFactory', 'PrimaryResourceBuilderFactory', 'PrimaryResourceTransformerFactory', 'ManyResourceMapperFactory'])];
-    }});
+  Inject(factory(TemplatedUrlFromUrl), factory(ResourceBuilder), factory(PrimaryResourceBuilder), factory(PrimaryResourceTransformer), factory(ManyResourceMapper), factory(TemporaryTemplatedUrl))(ListResourceMapper);
   return {
     get default() {
       return $__default;
@@ -3102,37 +4088,31 @@ define('relayer/mappers/ListResourceMapper',["../SimpleFactoryInjector", "./Reso
   };
 });
 
-define('relayer/mappers/MapResourceMapper',["../SimpleFactoryInjector", "./Mapper"], function($__0,$__2) {
-
+define('relayer/serializers/ListResourceSerializer',["./Serializer", "./ManyResourceSerializer", "../injector"], function($__0,$__2,$__4) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
-  var SimpleFactory = $__0.SimpleFactory;
-  var Mapper = $__2.default;
-  var MapResourceMapper = function MapResourceMapper(singleRelationshipDescriptionFactory, transport, response, relationshipDescription) {
-    var useErrors = arguments[4] !== (void 0) ? arguments[4] : false;
-    $traceurRuntime.superConstructor($MapResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
-    this.singleRelationshipDescription = singleRelationshipDescriptionFactory("", this.ResourceClass);
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var Serializer = $__0.default;
+  var ManyResourceSerializer = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var ListResourceSerializer = function ListResourceSerializer(manyResourceSerializerFactory, resource) {
+    $traceurRuntime.superConstructor($ListResourceSerializer).call(this, resource);
+    this.manyResourceSerializerFactory = manyResourceSerializerFactory;
   };
-  var $MapResourceMapper = MapResourceMapper;
-  ($traceurRuntime.createClass)(MapResourceMapper, {
-    initializeModel: function() {
-      this.mapped = {};
-    },
-    mapNestedRelationships: function() {
-      var $__4 = this;
-      Object.keys(this.response).forEach((function(responseKey) {
-        var response = $__4.response[responseKey];
-        var singleResourceMapper = $__4.singleRelationshipDescription.mapperFactory($__4.transport, response, $__4.singleRelationshipDescription);
-        $__4.mapped[responseKey] = singleResourceMapper.map();
-      }));
-    }
-  }, {}, Mapper);
-  var $__default = MapResourceMapper;
-  Object.defineProperty(MapResourceMapper, "annotations", {get: function() {
-      return [new SimpleFactory("MapResourceMapperFactory", ["SingleRelationshipDescriptionFactory"])];
-    }});
+  var $ListResourceSerializer = ListResourceSerializer;
+  ($traceurRuntime.createClass)(ListResourceSerializer, {serialize: function() {
+      var data = this.manyResourceSerializerFactory(this.resource).serialize();
+      this.resource.resource.pathSet("$.data", data);
+      return this.resource.resource.response;
+    }}, {}, Serializer);
+  var $__default = ListResourceSerializer;
+  Inject(factory(ManyResourceSerializer))(ListResourceSerializer);
   return {
     get default() {
       return $__default;
@@ -3141,273 +4121,19 @@ define('relayer/mappers/MapResourceMapper',["../SimpleFactoryInjector", "./Mappe
   };
 });
 
-define('relayer/mappers',["./mappers/ResourceMapper", "./mappers/ManyResourceMapper", "./mappers/ListResourceMapper", "./mappers/MapResourceMapper"], function($__0,$__1,$__2,$__3) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__3 || !$__3.__esModule)
-    $__3 = {default: $__3};
-  var $__mappers_47_ResourceMapper_46_js__ = $__0;
-  var $__mappers_47_ManyResourceMapper_46_js__ = $__1;
-  var $__mappers_47_ListResourceMapper_46_js__ = $__2;
-  var $__mappers_47_MapResourceMapper_46_js__ = $__3;
-  return {
-    get ResourceMapper() {
-      return $__mappers_47_ResourceMapper_46_js__.default;
-    },
-    get ManyResourceMapper() {
-      return $__mappers_47_ManyResourceMapper_46_js__.default;
-    },
-    get ListResourceMapper() {
-      return $__mappers_47_ListResourceMapper_46_js__.default;
-    },
-    get MapResourceMapper() {
-      return $__mappers_47_MapResourceMapper_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/ResourceTransformer',[], function() {
-
-  var ResourceTransformer = function ResourceTransformer() {
-    ;
-  };
-  ($traceurRuntime.createClass)(ResourceTransformer, {
-    transformRequest: function(endpoint, resource) {
-      return resource;
-    },
-    transformResponse: function(endpoint, response) {
-      return response;
-    }
-  }, {});
-  var $__default = ResourceTransformer;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/PrimaryResourceTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
+define('relayer/transformers/IndividualFromListTransformer',["./ResourceTransformer", "../TemplatedUrl", "../injector"], function($__0,$__2,$__4) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
   var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var PrimaryResourceTransformer = function PrimaryResourceTransformer(relationshipDescription) {
-    $traceurRuntime.superConstructor($PrimaryResourceTransformer).call(this);
-    this.relationshipDescription = relationshipDescription;
-  };
-  var $PrimaryResourceTransformer = PrimaryResourceTransformer;
-  ($traceurRuntime.createClass)(PrimaryResourceTransformer, {
-    get primaryResourceSerializerFactory() {
-      return this.relationshipDescription.serializerFactory;
-    },
-    get primaryResourceMapperFactory() {
-      return this.relationshipDescription.mapperFactory;
-    },
-    transformRequest: function(endpoint, resource) {
-      return this.primaryResourceSerializerFactory(resource).serialize();
-    },
-    transformResponse: function(endpoint, response) {
-      var $__4 = this;
-      return response.then((function(resolvedResponse) {
-        endpoint.templatedUrl.etag = resolvedResponse.etag;
-        return $__4.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, $__4.relationshipDescription, endpoint).map();
-      })).catch((function(resolvedError) {
-        throw $__4.primaryResourceMapperFactory(endpoint.transport, resolvedError.data, $__4.relationshipDescription, endpoint, true).map();
-      }));
-    }
-  }, {}, ResourceTransformer);
-  var $__default = PrimaryResourceTransformer;
-  Object.defineProperty(PrimaryResourceTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('PrimaryResourceTransformerFactory', [])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/CreateResourceTransformer',["./PrimaryResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var PrimaryResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var CreateResourceTransformer = function CreateResourceTransformer(relationshipDescription, uriTemplate) {
-    $traceurRuntime.superConstructor($CreateResourceTransformer).call(this, relationshipDescription);
-    this.uriTemplate = uriTemplate;
-  };
-  var $CreateResourceTransformer = CreateResourceTransformer;
-  ($traceurRuntime.createClass)(CreateResourceTransformer, {transformResponse: function(endpoint, response) {
-      var $__4 = this;
-      return response.then((function(resolvedResponse) {
-        var resourceMapper = $__4.primaryResourceMapperFactory(endpoint.transport, resolvedResponse.data, $__4.relationshipDescription);
-        resourceMapper.uriTemplate = $__4.uriTemplate;
-        var resource = resourceMapper.map();
-        resource.templatedUrl.etag = resolvedResponse.etag;
-        return resource;
-      })).catch((function(resolvedError) {
-        throw $__4.primaryResourceMapperFactory(endpoint.transport, resolvedError.data, $__4.relationshipDescription, null, true).map();
-      }));
-    }}, {}, PrimaryResourceTransformer);
-  var $__default = CreateResourceTransformer;
-  Object.defineProperty(CreateResourceTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('CreateResourceTransformerFactory', [])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/EmbeddedPropertyTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var EmbeddedPropertyTransformer = function EmbeddedPropertyTransformer(path) {
-    $traceurRuntime.superConstructor($EmbeddedPropertyTransformer).call(this);
-    this.path = path;
-  };
-  var $EmbeddedPropertyTransformer = EmbeddedPropertyTransformer;
-  ($traceurRuntime.createClass)(EmbeddedPropertyTransformer, {
-    transformRequest: function(endpoint, value) {
-      var resource = endpoint.resource;
-      resource.pathSet(this.path, value);
-      return resource;
-    },
-    transformResponse: function(endpoint, response) {
-      var $__4 = this;
-      return response.then((function(resource) {
-        endpoint.resource = resource;
-        return resource.pathGet($__4.path);
-      })).catch((function(error) {
-        throw error.pathGet($__4.path);
-      }));
-    }
-  }, {}, ResourceTransformer);
-  var $__default = EmbeddedPropertyTransformer;
-  Object.defineProperty(EmbeddedPropertyTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('EmbeddedPropertyTransformerFactory')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/EmbeddedRelationshipTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var EmbeddedRelationshipTransformer = function EmbeddedRelationshipTransformer(relationshipName) {
-    $traceurRuntime.superConstructor($EmbeddedRelationshipTransformer).call(this);
-    this.relationshipName = relationshipName;
-  };
-  var $EmbeddedRelationshipTransformer = EmbeddedRelationshipTransformer;
-  ($traceurRuntime.createClass)(EmbeddedRelationshipTransformer, {
-    transformRequest: function(endpoint, value) {
-      var resource = endpoint.resource;
-      resource.relationships[this.relationshipName] = value;
-      return resource;
-    },
-    transformResponse: function(endpoint, response) {
-      var $__4 = this;
-      return response.then((function(resource) {
-        endpoint.resource = resource;
-        return resource.relationships[$__4.relationshipName];
-      })).catch((function(error) {
-        throw error.relationships[$__4.relationshipName];
-      }));
-    }
-  }, {}, ResourceTransformer);
-  var $__default = EmbeddedRelationshipTransformer;
-  Object.defineProperty(EmbeddedRelationshipTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('EmbeddedRelationshipTransformerFactory')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/SingleFromManyTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var SingleFromManyTransformer = function SingleFromManyTransformer(relationshipName, property) {
-    $traceurRuntime.superConstructor($SingleFromManyTransformer).call(this);
-    this.property = property;
-    this.relationshipName = relationshipName;
-  };
-  var $SingleFromManyTransformer = SingleFromManyTransformer;
-  ($traceurRuntime.createClass)(SingleFromManyTransformer, {
-    transformRequest: function(endpoint, value) {
-      var resource = endpoint.resource;
-      resource.relationships[this.relationshipName][this.property] = value;
-      return resource;
-    },
-    transformResponse: function(endpoint, response) {
-      var $__4 = this;
-      return response.then((function(resource) {
-        endpoint.resource = resource;
-        return resource.relationships[$__4.relationshipName][$__4.property];
-      })).catch((function(error) {
-        throw error.relationships[$__4.relationshipName][$__4.property];
-      }));
-    }
-  }, {}, ResourceTransformer);
-  var $__default = SingleFromManyTransformer;
-  Object.defineProperty(SingleFromManyTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('SingleFromManyTransformerFactory')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers/IndividualFromListTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
+  var TemplatedUrl = $__2.TemplatedUrl;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
   var IndividualFromListTransformer = function IndividualFromListTransformer(templatedUrlFactory, relationshipName, uriParams) {
     $traceurRuntime.superConstructor($IndividualFromListTransformer).call(this);
     this.templatedUrlFactory = templatedUrlFactory;
@@ -3434,24 +4160,22 @@ define('relayer/transformers/IndividualFromListTransformer',["./ResourceTransfor
       return resource;
     },
     transformResponse: function(endpoint, response) {
-      var $__4 = this;
+      var $__6 = this;
       return response.then((function(resource) {
         endpoint.resource = resource;
-        var elementIndex = $__4.findInRelationship(resource.relationships[$__4.relationshipName]);
+        var elementIndex = $__6.findInRelationship(resource.relationships[$__6.relationshipName]);
         if (elementIndex == -1) {
           throw "Element Not Found In List";
         } else {
-          return resource.relationships[$__4.relationshipName][elementIndex];
+          return resource.relationships[$__6.relationshipName][elementIndex];
         }
       })).catch((function(error) {
-        throw resource.relationshipName[$__4.relationshipName];
+        throw resource.relationshipName[$__6.relationshipName];
       }));
     }
   }, {}, ResourceTransformer);
   var $__default = IndividualFromListTransformer;
-  Object.defineProperty(IndividualFromListTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('IndividualFromListTransformerFactory', ['TemplatedUrlFactory'])];
-    }});
+  Inject(factory(TemplatedUrl))(IndividualFromListTransformer);
   return {
     get default() {
       return $__default;
@@ -3460,726 +4184,58 @@ define('relayer/transformers/IndividualFromListTransformer',["./ResourceTransfor
   };
 });
 
-define('relayer/transformers/ThrowErrorTransformer',["./ResourceTransformer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
+define('relayer/relationshipDescriptions/ListRelationshipDescription',["./RelationshipDescription", "../initializers/ListRelationshipInitializer", "../mappers/ListResourceMapper", "../serializers/ListResourceSerializer", "xing-inflector", "./SingleRelationshipDescription", "../ListResource", "../transformers/PrimaryResourceTransformer", "../transformers/EmbeddedRelationshipTransformer", "../transformers/IndividualFromListTransformer", "../transformers/CreateResourceTransformer", "../endpoints/ResolvedEndpoint", "../endpoints/LoadedDataEndpoint", "../TemplatedUrl", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16,$__18,$__20,$__22,$__24,$__26,$__28) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
-  var ResourceTransformer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ThrowErrorTransformer = function ThrowErrorTransformer() {
-    $traceurRuntime.superConstructor($ThrowErrorTransformer).apply(this, arguments);
-    ;
-  };
-  var $ThrowErrorTransformer = ThrowErrorTransformer;
-  ($traceurRuntime.createClass)(ThrowErrorTransformer, {
-    transformRequest: function(endpoint, resource) {
-      throw "This Resource Cannot Be Updated Or Created";
-    },
-    transformResponse: function(endpoint, response) {
-      throw "There is no Resource To Create From This Response";
-    }
-  }, {}, ResourceTransformer);
-  var $__default = ThrowErrorTransformer;
-  Object.defineProperty(ThrowErrorTransformer, "annotations", {get: function() {
-      return [new SimpleFactory('ThrowErrorTransformerFactory')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/transformers',["./transformers/PrimaryResourceTransformer", "./transformers/CreateResourceTransformer", "./transformers/EmbeddedPropertyTransformer", "./transformers/EmbeddedRelationshipTransformer", "./transformers/SingleFromManyTransformer", "./transformers/IndividualFromListTransformer", "./transformers/ThrowErrorTransformer"], function($__0,$__1,$__2,$__3,$__4,$__5,$__6) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__3 || !$__3.__esModule)
-    $__3 = {default: $__3};
   if (!$__4 || !$__4.__esModule)
     $__4 = {default: $__4};
-  if (!$__5 || !$__5.__esModule)
-    $__5 = {default: $__5};
   if (!$__6 || !$__6.__esModule)
     $__6 = {default: $__6};
-  var $__transformers_47_PrimaryResourceTransformer_46_js__ = $__0;
-  var $__transformers_47_CreateResourceTransformer_46_js__ = $__1;
-  var $__transformers_47_EmbeddedPropertyTransformer_46_js__ = $__2;
-  var $__transformers_47_EmbeddedRelationshipTransformer_46_js__ = $__3;
-  var $__transformers_47_SingleFromManyTransformer_46_js__ = $__4;
-  var $__transformers_47_IndividualFromListTransformer_46_js__ = $__5;
-  var $__transformers_47_ThrowErrorTransformer_46_js__ = $__6;
-  return {
-    get PrimaryResourceTransformer() {
-      return $__transformers_47_PrimaryResourceTransformer_46_js__.default;
-    },
-    get CreateResourceTransformer() {
-      return $__transformers_47_CreateResourceTransformer_46_js__.default;
-    },
-    get EmbeddedPropertyTransformer() {
-      return $__transformers_47_EmbeddedPropertyTransformer_46_js__.default;
-    },
-    get EmbeddedRelationshipTransformer() {
-      return $__transformers_47_EmbeddedRelationshipTransformer_46_js__.default;
-    },
-    get SingleFromManyTransformer() {
-      return $__transformers_47_SingleFromManyTransformer_46_js__.default;
-    },
-    get IndividualFromListTransformer() {
-      return $__transformers_47_IndividualFromListTransformer_46_js__.default;
-    },
-    get ThrowErrorTransformer() {
-      return $__transformers_47_ThrowErrorTransformer_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers/RelationshipInitializer',[], function() {
-
-  var RelationshipInitializer = function RelationshipInitializer(ResourceClass, initialValues) {
-    this.ResourceClass = ResourceClass;
-    this.initialValues = initialValues;
-  };
-  ($traceurRuntime.createClass)(RelationshipInitializer, {initialize: function() {}}, {});
-  var $__default = RelationshipInitializer;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers/SingleRelationshipInitializer',["./RelationshipInitializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var RelationshipInitializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var SingleRelationshipInitializer = function SingleRelationshipInitializer() {
-    $traceurRuntime.superConstructor($SingleRelationshipInitializer).apply(this, arguments);
-    ;
-  };
-  var $SingleRelationshipInitializer = SingleRelationshipInitializer;
-  ($traceurRuntime.createClass)(SingleRelationshipInitializer, {initialize: function() {
-      var $__4 = this;
-      var relationship = new this.ResourceClass();
-      if (this.initialValues) {
-        Object.keys(this.initialValues).forEach((function(property) {
-          relationship[property] = $__4.initialValues[property];
-        }));
-      }
-      return relationship;
-    }}, {}, RelationshipInitializer);
-  var $__default = SingleRelationshipInitializer;
-  Object.defineProperty(SingleRelationshipInitializer, "annotations", {get: function() {
-      return [new SimpleFactory('SingleRelationshipInitializerFactory', [])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers/ManyRelationshipInitializer',["./RelationshipInitializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var RelationshipInitializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ManyRelationshipInitializer = function ManyRelationshipInitializer(singleRelationshipInitializerFactory, ResourceClass, initialValues) {
-    $traceurRuntime.superConstructor($ManyRelationshipInitializer).call(this, ResourceClass, initialValues);
-    this.singleRelationshipInitializerFactory = singleRelationshipInitializerFactory;
-  };
-  var $ManyRelationshipInitializer = ManyRelationshipInitializer;
-  ($traceurRuntime.createClass)(ManyRelationshipInitializer, {initialize: function() {
-      var $__4 = this;
-      var relationship = [];
-      var response = [];
-      if (this.initialValues) {
-        this.initialValues.forEach((function(initialValue) {
-          var singleInitializer = $__4.singleRelationshipInitializerFactory($__4.ResourceClass, initialValue);
-          var singleRelationship = singleInitializer.initialize();
-          relationship.push(singleRelationship);
-          response.push(singleRelationship.response);
-        }));
-      }
-      return relationship;
-    }}, {}, RelationshipInitializer);
-  var $__default = ManyRelationshipInitializer;
-  Object.defineProperty(ManyRelationshipInitializer, "annotations", {get: function() {
-      return [new SimpleFactory('ManyRelationshipInitializerFactory', ['SingleRelationshipInitializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers/ListRelationshipInitializer',["./RelationshipInitializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var RelationshipInitializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ListRelationshipInitializer = function ListRelationshipInitializer(ListResource, manyRelationshipInitializerFactory, ResourceClass, initialValues) {
-    $traceurRuntime.superConstructor($ListRelationshipInitializer).call(this, ResourceClass, initialValues);
-    this.manyRelationshipInitializer = manyRelationshipInitializerFactory(ResourceClass, initialValues);
-    this.ListResource = ListResource;
-  };
-  var $ListRelationshipInitializer = ListRelationshipInitializer;
-  ($traceurRuntime.createClass)(ListRelationshipInitializer, {initialize: function() {
-      var manyRelationships = this.manyRelationshipInitializer.initialize();
-      var resource = new this.ListResource({
-        data: manyRelationships.response,
-        links: {}
-      });
-      manyRelationships.resource = resource;
-      ["url", "uriTemplate", "uriParams", "create", "remove", "update", "load"].forEach((function(func) {
-        manyRelationships[func] = function() {
-          var $__6;
-          for (var args = [],
-              $__5 = 0; $__5 < arguments.length; $__5++)
-            args[$__5] = arguments[$__5];
-          return ($__6 = resource)[func].apply($__6, $traceurRuntime.spread(args));
-        };
-      }));
-      return manyRelationships;
-    }}, {}, RelationshipInitializer);
-  var $__default = ListRelationshipInitializer;
-  Object.defineProperty(ListRelationshipInitializer, "annotations", {get: function() {
-      return [new SimpleFactory('ListRelationshipInitializerFactory', ['ListResource', 'ManyRelationshipInitializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers/MapRelationshipInitializer',["./RelationshipInitializer", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var RelationshipInitializer = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var MapRelationshipInitializer = function MapRelationshipInitializer(singleRelationshipInitializerFactory, ResourceClass, initialValues) {
-    $traceurRuntime.superConstructor($MapRelationshipInitializer).call(this, ResourceClass, initialValues);
-    this.singleRelationshipInitializerFactory = singleRelationshipInitializerFactory;
-  };
-  var $MapRelationshipInitializer = MapRelationshipInitializer;
-  ($traceurRuntime.createClass)(MapRelationshipInitializer, {initialize: function() {
-      var $__4 = this;
-      var relationship = {};
-      var response = {};
-      if (this.initialValues) {
-        Object.keys(this.initialValues).forEach((function(key) {
-          var singleInitializer = $__4.singleRelationshipInitializerFactory($__4.ResourceClass, $__4.initialValues[key]);
-          var singleRelationship = singleInitializer.initialize();
-          relationship[key] = singleRelationship;
-          response[key] = singleRelationship.response;
-        }));
-      }
-      return relationship;
-    }}, {}, RelationshipInitializer);
-  var $__default = MapRelationshipInitializer;
-  Object.defineProperty(MapRelationshipInitializer, "annotations", {get: function() {
-      return [new SimpleFactory('MapRelationshipInitializerFactory', ['SingleRelationshipInitializerFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/initializers',["./initializers/SingleRelationshipInitializer", "./initializers/ManyRelationshipInitializer", "./initializers/ListRelationshipInitializer", "./initializers/MapRelationshipInitializer"], function($__0,$__1,$__2,$__3) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__3 || !$__3.__esModule)
-    $__3 = {default: $__3};
-  var $__initializers_47_SingleRelationshipInitializer_46_js__ = $__0;
-  var $__initializers_47_ManyRelationshipInitializer_46_js__ = $__1;
-  var $__initializers_47_ListRelationshipInitializer_46_js__ = $__2;
-  var $__initializers_47_MapRelationshipInitializer_46_js__ = $__3;
-  return {
-    get SingleRelationshipInitializer() {
-      return $__initializers_47_SingleRelationshipInitializer_46_js__.default;
-    },
-    get ManyRelationshipInitializer() {
-      return $__initializers_47_ManyRelationshipInitializer_46_js__.default;
-    },
-    get ListRelationshipInitializer() {
-      return $__initializers_47_ListRelationshipInitializer_46_js__.default;
-    },
-    get MapRelationshipInitializer() {
-      return $__initializers_47_MapRelationshipInitializer_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/decorators/ResourceDecorator',[], function() {
-
-  var ResourceDecorator = function ResourceDecorator(name) {
-    this.name = name;
-  };
-  ($traceurRuntime.createClass)(ResourceDecorator, {
-    addFunction: function(target, func) {
-      if (!(target.hasOwnProperty(this.name))) {
-        target[this.name] = func;
-      }
-    },
-    resourceApply: function(resource) {},
-    errorsApply: function(errors) {},
-    endpointApply: function(endpoint) {}
-  }, {});
-  var $__default = ResourceDecorator;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/decorators/JsonPropertyDecorator',["./ResourceDecorator", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var ResourceDecorator = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var JsonPropertyDecorator = function JsonPropertyDecorator(loadedDataEndpointFactory, embeddedPropertyTransformerFactory, promiseEndpointFactory, name, path, value, options) {
-    $traceurRuntime.superConstructor($JsonPropertyDecorator).call(this, name);
-    this.path = path;
-    this.options = options || {};
-    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
-    this.embeddedPropertyTransformerFactory = embeddedPropertyTransformerFactory;
-    this.promiseEndpointFactory = promiseEndpointFactory;
-    this.value = value;
-  };
-  var $JsonPropertyDecorator = JsonPropertyDecorator;
-  ($traceurRuntime.createClass)(JsonPropertyDecorator, {
-    recordApply: function(target) {
-      target.constructor.properties[this.name] = this.path;
-      if (!(target.hasOwnProperty(this.name))) {
-        var afterSet = this.options.afterSet;
-        var path = this.path;
-        Object.defineProperty(target, this.name, {
-          enumerable: true,
-          configurable: true,
-          get: function() {
-            return this.pathGet(path);
-          },
-          set: function(value) {
-            var result = this.pathSet(path, value);
-            if (afterSet) {
-              afterSet.call(this);
-            }
-            return result;
-          }
-        });
-      }
-    },
-    resourceApply: function(resource) {
-      if (this.value !== undefined) {
-        resource.setInitialValue(this.path, this.value);
-      }
-      this.recordApply(resource);
-    },
-    errorsApply: function(errors) {
-      this.recordApply(errors);
-    },
-    get endpointFn() {
-      if (!this._endpointFn) {
-        var path = this.path;
-        var promiseEndpointFactory = this.promiseEndpointFactory;
-        var loadedDataEndpointFactory = this.loadedDataEndpointFactory;
-        var embeddedPropertyTransformerFactory = this.embeddedPropertyTransformerFactory;
-        this._endpointFn = function() {
-          var uriParams = arguments[0] !== (void 0) ? arguments[0] : {};
-          var $__4 = this;
-          var newPromise = (function() {
-            return $__4.load().then((function(resource) {
-              return loadedDataEndpointFactory(resource.self(), resource, [embeddedPropertyTransformerFactory(path)]);
-            }));
-          });
-          var newEndpoint = promiseEndpointFactory(newPromise);
-          return newEndpoint;
-        };
-      }
-      return this._endpointFn;
-    },
-    endpointApply: function(target) {
-      this.addFunction(target, this.endpointFn);
-    }
-  }, {}, ResourceDecorator);
-  var $__default = JsonPropertyDecorator;
-  Object.defineProperty(JsonPropertyDecorator, "annotations", {get: function() {
-      return [new SimpleFactory('JsonPropertyDecoratorFactory', ['LoadedDataEndpointFactory', 'EmbeddedPropertyTransformerFactory', 'PromiseEndpointFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/decorators/RelatedResourceDecorator',["./ResourceDecorator", "../TemplatedUrl", "../SimpleFactoryInjector"], function($__0,$__2,$__4) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__4 || !$__4.__esModule)
-    $__4 = {default: $__4};
-  var ResourceDecorator = $__0.default;
-  var TemplatedUrl = $__2.TemplatedUrl;
-  var SimpleFactory = $__4.SimpleFactory;
-  var RelatedResourceDecorator = function RelatedResourceDecorator(promiseEndpointFactory, relationshipUtilities, name, relationship) {
-    $traceurRuntime.superConstructor($RelatedResourceDecorator).call(this, name);
-    this.promiseEndpointFactory = promiseEndpointFactory;
-    this.relationshipUtilities = relationshipUtilities;
-    this.relationship = relationship;
-  };
-  var $RelatedResourceDecorator = RelatedResourceDecorator;
-  ($traceurRuntime.createClass)(RelatedResourceDecorator, {
-    get resourceFn() {
-      if (!this._resourceFn) {
-        var name = this.name;
-        var relationship = this.relationship;
-        var promiseEndpointFactory = this.promiseEndpointFactory;
-        var relationshipUtilities = this.relationshipUtilities;
-        this._resourceFn = function(uriParams) {
-          var recursiveCall = arguments[1] !== (void 0) ? arguments[1] : false;
-          var $__6 = this;
-          if (relationship.async && this.isPersisted) {
-            var endpoint;
-            if (!this.relationships[name]) {
-              if (recursiveCall == false) {
-                endpoint = promiseEndpointFactory((function() {
-                  return $__6.self().load().then((function(resource) {
-                    return resource[name](uriParams, true);
-                  }));
-                }));
-              } else {
-                throw "Error: Unable to find relationship, even on canonical resource";
-              }
-            } else if (this.relationships[name] instanceof TemplatedUrl) {
-              endpoint = relationship.linkedEndpoint(this, uriParams);
-            } else {
-              endpoint = relationship.embeddedEndpoint(this, uriParams);
-            }
-            relationship.ResourceClass.resourceDescription.applyToEndpoint(endpoint);
-            relationshipUtilities.addMethods(endpoint, this, name);
-            return endpoint;
-          } else {
-            if (this.relationships[name] instanceof TemplatedUrl) {
-              throw "Error: non-async relationships must be embedded";
-            } else {
-              if (uriParams) {
-                return this.relationships[name][uriParams];
-              } else {
-                return this.relationships[name];
-              }
-            }
-          }
-        };
-      }
-      return this._resourceFn;
-    },
-    get errorFn() {
-      if (!this._errorFn) {
-        var name = this.name;
-        var path = this.path;
-        var relationship = this.relationship;
-        this._errorFn = function(uriParams) {
-          if (this.relationships[name] instanceof TemplatedUrl) {
-            throw "Error: non-async relationships must be embedded";
-          } else {
-            if (uriParams) {
-              return this.relationships[name][uriParams];
-            } else {
-              return this.relationships[name];
-            }
-          }
-        };
-      }
-      return this._errorFn;
-    },
-    get endpointFn() {
-      if (!this._endpointFn) {
-        var name = this.name;
-        var description = this.relationship.ResourceClass.resourceDescription;
-        var relationship = this.relationship;
-        var promiseEndpointFactory = this.promiseEndpointFactory;
-        this._endpointFn = function() {
-          var uriParams = arguments[0] !== (void 0) ? arguments[0] : {};
-          var $__6 = this;
-          var newPromise = (function() {
-            return $__6.load().then((function(resource) {
-              if (relationship.async) {
-                return resource[name](uriParams);
-              } else {
-                var endpoint = relationship.embeddedEndpoint(resource, uriParams);
-                description.applyToEndpoint(endpoint);
-                return endpoint;
-              }
-            }));
-          });
-          var newEndpoint = promiseEndpointFactory(newPromise);
-          relationship.decorateEndpoint(newEndpoint, uriParams);
-          description.applyToEndpoint(newEndpoint);
-          return newEndpoint;
-        };
-      }
-      return this._endpointFn;
-    },
-    resourceApply: function(target) {
-      target.constructor.relationships[this.name] = this.relationship;
-      this.addFunction(target, this.resourceFn);
-    },
-    errorsApply: function(target) {
-      target.constructor.relationships[this.name] = this.relationship;
-      this.addFunction(target, this.errorFn);
-    },
-    endpointApply: function(target) {
-      this.addFunction(target, this.endpointFn);
-    }
-  }, {}, ResourceDecorator);
-  var $__default = RelatedResourceDecorator;
-  Object.defineProperty(RelatedResourceDecorator, "annotations", {get: function() {
-      return [new SimpleFactory("RelatedResourceDecoratorFactory", ['PromiseEndpointFactory', 'RelationshipUtilities'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/decorators',["./decorators/JsonPropertyDecorator", "./decorators/RelatedResourceDecorator"], function($__0,$__1) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  var $__decorators_47_JsonPropertyDecorator_46_js__ = $__0;
-  var $__decorators_47_RelatedResourceDecorator_46_js__ = $__1;
-  return {
-    get JsonPropertyDecorator() {
-      return $__decorators_47_JsonPropertyDecorator_46_js__.default;
-    },
-    get RelatedResourceDecorator() {
-      return $__decorators_47_RelatedResourceDecorator_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/relationshipDescriptions/RelationshipDescription',[], function() {
-
-  var RelationshipDescription = function RelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues) {
-    this.initializer = relationshipInitializerFactory(ResourceClass, initialValues);
-    this.mapperFactory = resourceMapperFactory;
-    this.serializerFactory = resourceSerializerFactory;
-    this.inflector = inflector;
-    this.name = name;
-    this.ResourceClass = ResourceClass;
-    this.initialValues = initialValues;
-    this.async = true;
-    if (initialValues == undefined) {
-      this.initializeOnCreate = false;
-    } else {
-      this.initializeOnCreate = true;
-    }
-  };
-  ($traceurRuntime.createClass)(RelationshipDescription, {
-    get linksPath() {
-      this._linksPath = this._linksPath || ("$.links." + this.inflector.underscore(this.name));
-      return this._linksPath;
-    },
-    set linksPath(linksPath) {
-      this._linksPath = linksPath;
-      return this._linksPath;
-    },
-    get dataPath() {
-      this._dataPath = this._dataPath || ("$.data." + this.inflector.underscore(this.name));
-      return this._dataPath;
-    },
-    set dataPath(dataPath) {
-      this._dataPath = dataPath;
-      return this._dataPath;
-    },
-    decorateEndpoint: function(endpoint, uriParams) {}
-  }, {});
-  var $__default = RelationshipDescription;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/relationshipDescriptions/SingleRelationshipDescription',["./RelationshipDescription", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
+  if (!$__18 || !$__18.__esModule)
+    $__18 = {default: $__18};
+  if (!$__20 || !$__20.__esModule)
+    $__20 = {default: $__20};
+  if (!$__22 || !$__22.__esModule)
+    $__22 = {default: $__22};
+  if (!$__24 || !$__24.__esModule)
+    $__24 = {default: $__24};
+  if (!$__26 || !$__26.__esModule)
+    $__26 = {default: $__26};
+  if (!$__28 || !$__28.__esModule)
+    $__28 = {default: $__28};
   var RelationshipDescription = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var SingleRelationshipDescription = function SingleRelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, primaryResourceTransformerFactory, embeddedRelationshipTransformerFactory, resolvedEndpointFactory, loadedDataEndpointFactory, templatedUrlFactory, name, ResourceClass, initialValues) {
-    $traceurRuntime.superConstructor($SingleRelationshipDescription).call(this, relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues);
-    this.primaryResourceTransformerFactory = primaryResourceTransformerFactory;
-    this.embeddedRelationshipTransformerFactory = embeddedRelationshipTransformerFactory;
-    this.resolvedEndpointFactory = resolvedEndpointFactory;
-    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
-    this.templatedUrlFactory = templatedUrlFactory;
-    this._templated = false;
-  };
-  var $SingleRelationshipDescription = SingleRelationshipDescription;
-  ($traceurRuntime.createClass)(SingleRelationshipDescription, {
-    set templated(templated) {
-      this._templated = templated;
-    },
-    get templated() {
-      return this._templated;
-    },
-    embeddedEndpoint: function(parent, uriParams) {
-      if (this._templated) {
-        throw "A templated hasOne relationship cannot be embedded";
-      }
-      var parentEndpoint = parent.self();
-      var embeddedRelationshipTransformer = this.embeddedRelationshipTransformerFactory(this.name);
-      return this.loadedDataEndpointFactory(parentEndpoint, parent, embeddedRelationshipTransformer);
-    },
-    linkedEndpoint: function(parent, uriParams) {
-      var transport = parent.self().transport;
-      var url = parent.pathGet(this.linksPath);
-      var params = this._templated ? uriParams : {};
-      var templatedUrl = this.templatedUrlFactory(url, params);
-      if (!this._templated) {
-        templatedUrl.addDataPathLink(parent, this.linksPath);
-      }
-      var primaryResourceTransformer = this.primaryResourceTransformerFactory(this);
-      return this.resolvedEndpointFactory(transport, templatedUrl, primaryResourceTransformer);
-    }
-  }, {}, RelationshipDescription);
-  var $__default = SingleRelationshipDescription;
-  Object.defineProperty(SingleRelationshipDescription, "annotations", {get: function() {
-      return [new SimpleFactory('SingleRelationshipDescriptionFactory', ['SingleRelationshipInitializerFactory', 'ResourceMapperFactory', 'ResourceSerializerFactory', 'Inflector', 'PrimaryResourceTransformerFactory', 'EmbeddedRelationshipTransformerFactory', 'ResolvedEndpointFactory', 'LoadedDataEndpointFactory', 'TemplatedUrlFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/relationshipDescriptions/MultipleRelationshipDescription',["./RelationshipDescription"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var RelationshipDescription = $__0.default;
-  var MultipleRelationshipDescription = function MultipleRelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, embeddedRelationshipTransformerFactory, singleFromManyTransformerFactory, loadedDataEndpointFactory, name, ResourceClass, initialValues) {
-    $traceurRuntime.superConstructor($MultipleRelationshipDescription).call(this, relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues);
-    this.embeddedRelationshipTransformerFactory = embeddedRelationshipTransformerFactory;
-    this.singleFromManyTransformerFactory = singleFromManyTransformerFactory;
-    this.loadedDataEndpointFactory = loadedDataEndpointFactory;
-  };
-  var $MultipleRelationshipDescription = MultipleRelationshipDescription;
-  ($traceurRuntime.createClass)(MultipleRelationshipDescription, {
-    embeddedEndpoint: function(parent, uriParams) {
-      var parentEndpoint = parent.self();
-      var transformer;
-      if (typeof uriParams == 'string') {
-        transformer = this.singleFromManyTransformerFactory(this.name, uriParams);
-      } else {
-        transformer = this.embeddedRelationshipTransformerFactory(this.name);
-      }
-      return this.loadedDataEndpointFactory(parentEndpoint, parent, transformer);
-    },
-    linkedEndpoint: function(parent, uriParams) {
-      throw "Error: a many relationships must be embedded";
-    }
-  }, {}, RelationshipDescription);
-  var $__default = MultipleRelationshipDescription;
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/relationshipDescriptions/ManyRelationshipDescription',["./MultipleRelationshipDescription", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var MultipleRelationshipDescription = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
-  var ManyRelationshipDescription = function ManyRelationshipDescription() {
-    $traceurRuntime.superConstructor($ManyRelationshipDescription).apply(this, arguments);
-    ;
-  };
-  var $ManyRelationshipDescription = ManyRelationshipDescription;
-  ($traceurRuntime.createClass)(ManyRelationshipDescription, {}, {}, MultipleRelationshipDescription);
-  var $__default = ManyRelationshipDescription;
-  Object.defineProperty(ManyRelationshipDescription, "annotations", {get: function() {
-      return [new SimpleFactory('ManyRelationshipDescriptionFactory', ['ManyRelationshipInitializerFactory', 'ManyResourceMapperFactory', 'ManyResourceSerializerFactory', 'Inflector', 'EmbeddedRelationshipTransformerFactory', 'SingleFromManyTransformerFactory', 'LoadedDataEndpointFactory'])];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/relationshipDescriptions/ListRelationshipDescription',["./RelationshipDescription", "../SimpleFactoryInjector"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var RelationshipDescription = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
+  var ListRelationshipInitializer = $__2.default;
+  var ListResourceMapper = $__4.default;
+  var ListResourceSerializer = $__6.default;
+  var Inflector = $__8.default;
+  var SingleRelationshipDescription = $__10.default;
+  var ListResource = $__12.default;
+  var PrimaryResourceTransformer = $__14.default;
+  var EmbeddedRelationshipTransformer = $__16.default;
+  var IndividualFromListTransformer = $__18.default;
+  var CreateResourceTransformer = $__20.default;
+  var ResolvedEndpoint = $__22.default;
+  var LoadedDataEndpoint = $__24.default;
+  var $__27 = $__26,
+      TemplatedUrl = $__27.TemplatedUrl,
+      TemplatedUrlFromUrl = $__27.TemplatedUrlFromUrl;
+  var $__29 = $__28,
+      Inject = $__29.Inject,
+      factory = $__29.factory,
+      value = $__29.value;
   var ListRelationshipDescription = function ListRelationshipDescription(relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, singleRelationshipDescriptionFactory, ListResource, primaryResourceTransformerFactory, embeddedRelationshipTransformerFactory, individualFromListTransformerFactory, createResourceTransformerFactory, resolvedEndpointFactory, loadedDataEndpointFactory, templatedUrlFromUrlFactory, templatedUrlFactory, name, ResourceClass, initialValues) {
     $traceurRuntime.superConstructor($ListRelationshipDescription).call(this, relationshipInitializerFactory, resourceMapperFactory, resourceSerializerFactory, inflector, name, ResourceClass, initialValues);
     this.singleRelationshipDescriptionFactory = singleRelationshipDescriptionFactory;
@@ -4283,9 +4339,7 @@ define('relayer/relationshipDescriptions/ListRelationshipDescription',["./Relati
     }
   }, {}, RelationshipDescription);
   var $__default = ListRelationshipDescription;
-  Object.defineProperty(ListRelationshipDescription, "annotations", {get: function() {
-      return [new SimpleFactory('ListRelationshipDescriptionFactory', ['ListRelationshipInitializerFactory', 'ListResourceMapperFactory', 'ListResourceSerializerFactory', 'Inflector', "SingleRelationshipDescriptionFactory", "ListResource", 'PrimaryResourceTransformerFactory', 'EmbeddedRelationshipTransformerFactory', 'IndividualFromListTransformerFactory', 'CreateResourceTransformerFactory', 'ResolvedEndpointFactory', 'LoadedDataEndpointFactory', 'TemplatedUrlFromUrlFactory', 'TemplatedUrlFactory'])];
-    }});
+  Inject(factory(ListRelationshipInitializer), factory(ListResourceMapper), factory(ListResourceSerializer), Inflector, factory(SingleRelationshipDescription), value(ListResource), factory(PrimaryResourceTransformer), factory(EmbeddedRelationshipTransformer), factory(IndividualFromListTransformer), factory(CreateResourceTransformer), factory(ResolvedEndpoint), factory(LoadedDataEndpoint), factory(TemplatedUrlFromUrl), factory(TemplatedUrl))(ListRelationshipDescription);
   return {
     get default() {
       return $__default;
@@ -4294,14 +4348,156 @@ define('relayer/relationshipDescriptions/ListRelationshipDescription',["./Relati
   };
 });
 
-define('relayer/relationshipDescriptions/MapRelationshipDescription',["./MultipleRelationshipDescription", "../SimpleFactoryInjector"], function($__0,$__2) {
-
+define('relayer/initializers/MapRelationshipInitializer',["./RelationshipInitializer", "./SingleRelationshipInitializer", "../injector"], function($__0,$__2,$__4) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var RelationshipInitializer = $__0.default;
+  var SingleRelationshipInitializer = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var MapRelationshipInitializer = function MapRelationshipInitializer(singleRelationshipInitializerFactory, ResourceClass, initialValues) {
+    $traceurRuntime.superConstructor($MapRelationshipInitializer).call(this, ResourceClass, initialValues);
+    this.singleRelationshipInitializerFactory = singleRelationshipInitializerFactory;
+  };
+  var $MapRelationshipInitializer = MapRelationshipInitializer;
+  ($traceurRuntime.createClass)(MapRelationshipInitializer, {initialize: function() {
+      var $__6 = this;
+      var relationship = {};
+      var response = {};
+      if (this.initialValues) {
+        Object.keys(this.initialValues).forEach((function(key) {
+          var singleInitializer = $__6.singleRelationshipInitializerFactory($__6.ResourceClass, $__6.initialValues[key]);
+          var singleRelationship = singleInitializer.initialize();
+          relationship[key] = singleRelationship;
+          response[key] = singleRelationship.response;
+        }));
+      }
+      return relationship;
+    }}, {}, RelationshipInitializer);
+  var $__default = MapRelationshipInitializer;
+  Inject(factory(SingleRelationshipInitializer))(MapRelationshipInitializer);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/mappers/MapResourceMapper',["./Mapper", "../relationshipDescriptions/SingleRelationshipDescription", "../injector"], function($__0,$__2,$__4) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var Mapper = $__0.default;
+  var SingleRelationshipDescription = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var MapResourceMapper = function MapResourceMapper(singleRelationshipDescriptionFactory, transport, response, relationshipDescription) {
+    var useErrors = arguments[4] !== (void 0) ? arguments[4] : false;
+    $traceurRuntime.superConstructor($MapResourceMapper).call(this, transport, response, relationshipDescription, useErrors);
+    this.singleRelationshipDescription = singleRelationshipDescriptionFactory("", this.ResourceClass);
+  };
+  var $MapResourceMapper = MapResourceMapper;
+  ($traceurRuntime.createClass)(MapResourceMapper, {
+    initializeModel: function() {
+      this.mapped = {};
+    },
+    mapNestedRelationships: function() {
+      var $__6 = this;
+      Object.keys(this.response).forEach((function(responseKey) {
+        var response = $__6.response[responseKey];
+        var singleResourceMapper = $__6.singleRelationshipDescription.mapperFactory($__6.transport, response, $__6.singleRelationshipDescription);
+        $__6.mapped[responseKey] = singleResourceMapper.map();
+      }));
+    }
+  }, {}, Mapper);
+  var $__default = MapResourceMapper;
+  Inject(factory(SingleRelationshipDescription))(MapResourceMapper);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/serializers/MapResourceSerializer',["./Serializer", "./ResourceSerializer", "../injector"], function($__0,$__2,$__4) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  var Serializer = $__0.default;
+  var ResourceSerializer = $__2.default;
+  var $__5 = $__4,
+      Inject = $__5.Inject,
+      factory = $__5.factory;
+  var MapResourceSerializer = function MapResourceSerializer(resourceSerializerFactory, resource) {
+    $traceurRuntime.superConstructor($MapResourceSerializer).call(this, resource);
+    this.resourceSerializerFactory = resourceSerializerFactory;
+  };
+  var $MapResourceSerializer = MapResourceSerializer;
+  ($traceurRuntime.createClass)(MapResourceSerializer, {serialize: function() {
+      var $__6 = this;
+      return Object.keys(this.resource).reduce((function(data, key) {
+        data[key] = $__6.resourceSerializerFactory($__6.resource[key]).serialize();
+        return data;
+      }), {});
+    }}, {}, Serializer);
+  var $__default = MapResourceSerializer;
+  Inject(factory(ResourceSerializer))(MapResourceSerializer);
+  return {
+    get default() {
+      return $__default;
+    },
+    __esModule: true
+  };
+});
+
+define('relayer/relationshipDescriptions/MapRelationshipDescription',["./MultipleRelationshipDescription", "../initializers/MapRelationshipInitializer", "../mappers/MapResourceMapper", "../serializers/MapResourceSerializer", "xing-inflector", "../transformers/EmbeddedRelationshipTransformer", "../transformers/SingleFromManyTransformer", "../endpoints/LoadedDataEndpoint", "../injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16) {
+  
+  if (!$__0 || !$__0.__esModule)
+    $__0 = {default: $__0};
+  if (!$__2 || !$__2.__esModule)
+    $__2 = {default: $__2};
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
   var MultipleRelationshipDescription = $__0.default;
-  var SimpleFactory = $__2.SimpleFactory;
+  var MapRelationshipInitializer = $__2.default;
+  var MapResourceMapper = $__4.default;
+  var MapResourceSerializer = $__6.default;
+  var Inflector = $__8.default;
+  var EmbeddedRelationshipTransformer = $__10.default;
+  var SingleFromManyTransformer = $__12.default;
+  var LoadedDataEndpoint = $__14.default;
+  var $__17 = $__16,
+      Inject = $__17.Inject,
+      factory = $__17.factory;
   var MapRelationshipDescription = function MapRelationshipDescription() {
     $traceurRuntime.superConstructor($MapRelationshipDescription).apply(this, arguments);
     ;
@@ -4309,9 +4505,7 @@ define('relayer/relationshipDescriptions/MapRelationshipDescription',["./Multipl
   var $MapRelationshipDescription = MapRelationshipDescription;
   ($traceurRuntime.createClass)(MapRelationshipDescription, {}, {}, MultipleRelationshipDescription);
   var $__default = MapRelationshipDescription;
-  Object.defineProperty(MapRelationshipDescription, "annotations", {get: function() {
-      return [new SimpleFactory('MapRelationshipDescriptionFactory', ['MapRelationshipInitializerFactory', 'MapResourceMapperFactory', 'MapResourceSerializerFactory', 'Inflector', 'EmbeddedRelationshipTransformerFactory', 'SingleFromManyTransformerFactory', 'LoadedDataEndpointFactory'])];
-    }});
+  Inject(factory(MapRelationshipInitializer), factory(MapResourceMapper), factory(MapResourceSerializer), Inflector, factory(EmbeddedRelationshipTransformer), factory(SingleFromManyTransformer), factory(LoadedDataEndpoint))(MapRelationshipDescription);
   return {
     get default() {
       return $__default;
@@ -4320,149 +4514,172 @@ define('relayer/relationshipDescriptions/MapRelationshipDescription',["./Multipl
   };
 });
 
-define('relayer/relationshipDescriptions',["./relationshipDescriptions/SingleRelationshipDescription", "./relationshipDescriptions/ManyRelationshipDescription", "./relationshipDescriptions/ListRelationshipDescription", "./relationshipDescriptions/MapRelationshipDescription"], function($__0,$__1,$__2,$__3) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__1 || !$__1.__esModule)
-    $__1 = {default: $__1};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  if (!$__3 || !$__3.__esModule)
-    $__3 = {default: $__3};
-  var $__relationshipDescriptions_47_SingleRelationshipDescription_46_js__ = $__0;
-  var $__relationshipDescriptions_47_ManyRelationshipDescription_46_js__ = $__1;
-  var $__relationshipDescriptions_47_ListRelationshipDescription_46_js__ = $__2;
-  var $__relationshipDescriptions_47_MapRelationshipDescription_46_js__ = $__3;
-  return {
-    get SingleRelationshipDescription() {
-      return $__relationshipDescriptions_47_SingleRelationshipDescription_46_js__.default;
-    },
-    get ManyRelationshipDescription() {
-      return $__relationshipDescriptions_47_ManyRelationshipDescription_46_js__.default;
-    },
-    get ListRelationshipDescription() {
-      return $__relationshipDescriptions_47_ListRelationshipDescription_46_js__.default;
-    },
-    get MapRelationshipDescription() {
-      return $__relationshipDescriptions_47_MapRelationshipDescription_46_js__.default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer/ListResource',["./Resource", "a1atscript"], function($__0,$__2) {
-
+define('relayer/ResourceDescription',["./APIError", "./decorators/JsonPropertyDecorator", "./decorators/RelatedResourceDecorator", "./relationshipDescriptions/SingleRelationshipDescription", "./relationshipDescriptions/ManyRelationshipDescription", "./relationshipDescriptions/ListRelationshipDescription", "./relationshipDescriptions/MapRelationshipDescription", "xing-inflector", "./injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
-  var Resource = $__0.default;
-  var Value = $__2.Value;
-  var ListResource = function ListResource() {
-    $traceurRuntime.superConstructor($ListResource).apply(this, arguments);
-    ;
+  if (!$__4 || !$__4.__esModule)
+    $__4 = {default: $__4};
+  if (!$__6 || !$__6.__esModule)
+    $__6 = {default: $__6};
+  if (!$__8 || !$__8.__esModule)
+    $__8 = {default: $__8};
+  if (!$__10 || !$__10.__esModule)
+    $__10 = {default: $__10};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
+  var APIError = $__0.default;
+  var JsonPropertyDecorator = $__2.default;
+  var RelatedResourceDecorator = $__4.default;
+  var SingleRelationshipDescription = $__6.default;
+  var ManyRelationshipDescription = $__8.default;
+  var ListRelationshipDescription = $__10.default;
+  var MapRelationshipDescription = $__12.default;
+  var Inflector = $__14.default;
+  var $__17 = $__16,
+      Inject = $__17.Inject,
+      factory = $__17.factory;
+  var resourcesToInitialize = [];
+  function describeResource(resourceClass, defineFn) {
+    resourcesToInitialize.push({
+      resourceClass: resourceClass,
+      defineFn: defineFn
+    });
+  }
+  var InitializedResourceClasses = function InitializedResourceClasses(resourceDescriptionFactory) {
+    this.resourceDescriptionFactory = resourceDescriptionFactory;
+    this.initializeClasses();
   };
-  var $ListResource = ListResource;
-  ($traceurRuntime.createClass)(ListResource, {}, {}, Resource);
-  var $__default = ListResource;
-  Object.defineProperty(ListResource, "annotations", {get: function() {
-      return [new Value('ListResource')];
-    }});
-  return {
-    get default() {
-      return $__default;
+  ($traceurRuntime.createClass)(InitializedResourceClasses, {
+    buildDescription: function(resourceToInitialize) {
+      var resourceClass = resourceToInitialize.resourceClass;
+      var defineFn = resourceToInitialize.defineFn;
+      var resourceDescription = resourceClass.description(this.resourceDescriptionFactory);
+      defineFn(resourceDescription);
     },
-    __esModule: true
-  };
-});
-
-define('relayer/PrimaryResourceBuilder',["./SimpleFactoryInjector"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var SimpleFactory = $__0.SimpleFactory;
-  var PrimaryResourceBuilder = function PrimaryResourceBuilder(response, ResourceClass) {
-    this.response = response;
-    this.ResourceClass = ResourceClass;
-  };
-  ($traceurRuntime.createClass)(PrimaryResourceBuilder, {build: function(endpoint) {
-      var resource = new this.ResourceClass(this.response);
-      resource.templatedUrl = endpoint.templatedUrl;
-      resource.templatedUrl.addDataPathLink(resource, "$.links.self");
-      resource.self = function() {
-        return endpoint;
+    applyDescription: function(resourceToInitialize) {
+      var resourceClass = resourceToInitialize.resourceClass;
+      var resourceDescription = resourceClass.resourceDescription;
+      var errorClass = function(responseData) {
+        APIError.call(this, responseData);
       };
-      return resource;
-    }}, {});
-  var $__default = PrimaryResourceBuilder;
-  Object.defineProperty(PrimaryResourceBuilder, "annotations", {get: function() {
-      return [new SimpleFactory("PrimaryResourceBuilderFactory", [])];
-    }});
-  return {
-    get default() {
-      return $__default;
+      errorClass.relationships = {};
+      errorClass.properties = {};
+      errorClass.prototype = Object.create(APIError.prototype);
+      errorClass.prototype.constructor = errorClass;
+      resourceDescription.applyToResource(resourceClass.prototype);
+      resourceDescription.applyToError(errorClass.prototype);
+      resourceClass.errorClass = errorClass;
+      return resourceClass;
     },
-    __esModule: true
+    initializeClasses: function() {
+      var $__18 = this;
+      resourcesToInitialize.forEach((function(resourceToInitialize) {
+        $__18.buildDescription(resourceToInitialize);
+      }));
+      return resourcesToInitialize.map((function(resourceToInitialize) {
+        $__18.applyDescription(resourceToInitialize);
+      }));
+    }
+  }, {});
+  var ResourceDescription = function ResourceDescription(jsonPropertyDecoratorFactory, relatedResourceDecoratorFactory, singleRelationshipDescriptionFactory, manyRelationshipDescriptionFactory, listRelationshipDescriptionFactory, mapRelationshipDescriptionFactory, inflector) {
+    this.jsonPropertyDecoratorFactory = jsonPropertyDecoratorFactory;
+    this.relatedResourceDecoratorFactory = relatedResourceDecoratorFactory;
+    this.singleRelationshipDescriptionFactory = singleRelationshipDescriptionFactory;
+    this.manyRelationshipDescriptionFactory = manyRelationshipDescriptionFactory;
+    this.listRelationshipDescriptionFactory = listRelationshipDescriptionFactory;
+    this.mapRelationshipDescriptionFactory = mapRelationshipDescriptionFactory;
+    this.inflector = inflector;
+    this.decorators = {};
+    this.allDecorators = [];
+    this.parentDescription = null;
   };
-});
-
-define('relayer/ResourceBuilder',["./SimpleFactoryInjector"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var SimpleFactory = $__0.SimpleFactory;
-  var ResourceBuilder = function ResourceBuilder(templatedUrlFromUrlFactory, resolvedEndpointFactory, throwErrorTransformerFactory, createResourceTransformerFactory, transport, response, primaryResourceTransformer, ResourceClass, relationshipDescription) {
-    this.transport = transport;
-    this.ResourceClass = ResourceClass;
-    this.relationshipDescription = relationshipDescription;
-    this.templatedUrlFromUrlFactory = templatedUrlFromUrlFactory;
-    this.resolvedEndpointFactory = resolvedEndpointFactory;
-    this.throwErrorTransformerFactory = throwErrorTransformerFactory;
-    this.createResourceTransformerFactory = createResourceTransformerFactory;
-    this.response = response;
-    this.primaryResourceTransformer = primaryResourceTransformer;
-  };
-  ($traceurRuntime.createClass)(ResourceBuilder, {build: function() {
-      var uriTemplate = arguments[0] !== (void 0) ? arguments[0] : null;
-      var resource = new this.ResourceClass(this.response);
-      if (resource.pathGet("$.links.self")) {
-        if (uriTemplate) {
-          resource.templatedUrl = this.templatedUrlFromUrlFactory(uriTemplate, resource.pathGet("$.links.self"));
-        } else {
-          resource.templatedUrl = this.templatedUrlFromUrlFactory(resource.pathGet("$.links.self"), resource.pathGet("$.links.self"));
-        }
-        resource.templatedUrl.addDataPathLink(resource, "$.links.self");
-        if (this.relationshipDescription.canCreate) {
-          var createUriTemplate = uriTemplate || resource.pathGet("$.links.template");
-          var createResourceTransformer = this.createResourceTransformerFactory(this.relationshipDescription.createRelationshipDescription, createUriTemplate);
-        } else {
-          var createResourceTransformer = this.throwErrorTransformerFactory();
-        }
-        var endpoint = this.resolvedEndpointFactory(this.transport, resource.templatedUrl, this.primaryResourceTransformer, createResourceTransformer);
-        resource.self = function() {
-          return endpoint;
-        };
+  ($traceurRuntime.createClass)(ResourceDescription, {
+    chainFrom: function(other) {
+      if (this.parentDescription && this.parentDescription !== other) {
+        throw new Error("Attempted to rechain description: existing parent if of " + (this.parentDescription.ResourceClass + ", new is of " + other.ResourceClass));
+      } else {
+        this.parentDescription = other;
       }
-      return resource;
-    }}, {});
-  var $__default = ResourceBuilder;
-  Object.defineProperty(ResourceBuilder, "annotations", {get: function() {
-      return [new SimpleFactory("ResourceBuilderFactory", ["TemplatedUrlFromUrlFactory", "ResolvedEndpointFactory", "ThrowErrorTransformerFactory", "CreateResourceTransformerFactory"])];
-    }});
+    },
+    recordDecorator: function(name, decoratorDescription) {
+      this.decorators[name] = this.decorators[name] || [];
+      this.decorators[name].push(decoratorDescription);
+      this.allDecorators.push(decoratorDescription);
+      return decoratorDescription;
+    },
+    applyToResource: function(resource) {
+      this.allDecorators.forEach((function(decorator) {
+        decorator.resourceApply(resource);
+      }));
+      if (this.parentDescription) {
+        this.parentDescription.applyToResource(resource);
+      }
+    },
+    applyToError: function(error) {
+      this.allDecorators.forEach((function(decorator) {
+        decorator.errorsApply(error);
+      }));
+      if (this.parentDescription) {
+        this.parentDescription.applyToError(error);
+      }
+    },
+    applyToEndpoint: function(endpoint) {
+      this.allDecorators.forEach((function(decorator) {
+        decorator.endpointApply(endpoint);
+      }));
+      if (this.parentDescription) {
+        this.parentDescription.applyToEndpoint(endpoint);
+      }
+    },
+    property: function(property, initial) {
+      this.jsonProperty(property, ("$.data." + this.inflector.underscore(property)), initial);
+    },
+    hasOne: function(property, rezClass, initialValues) {
+      return this.relatedResource(property, rezClass, initialValues, this.singleRelationshipDescriptionFactory);
+    },
+    hasMany: function(property, rezClass, initialValues) {
+      return this.relatedResource(property, rezClass, initialValues, this.manyRelationshipDescriptionFactory);
+    },
+    hasList: function(property, rezClass, initialValues) {
+      return this.relatedResource(property, rezClass, initialValues, this.listRelationshipDescriptionFactory);
+    },
+    hasMap: function(property, rezClass, initialValue) {
+      return this.relatedResource(property, rezClass, initialValue, this.mapRelationshipDescriptionFactory);
+    },
+    jsonProperty: function(name, path, value, options) {
+      return this.recordDecorator(name, this.jsonPropertyDecoratorFactory(name, path, value, options));
+    },
+    relatedResource: function(property, rezClass, initialValues, relationshipDescriptionFactory) {
+      var relationship = relationshipDescriptionFactory(property, rezClass, initialValues);
+      this.recordDecorator(name, this.relatedResourceDecoratorFactory(property, relationship));
+      return relationship;
+    }
+  }, {});
+  Inject(factory(ResourceDescription))(InitializedResourceClasses);
+  Inject(factory(JsonPropertyDecorator), factory(RelatedResourceDecorator), factory(SingleRelationshipDescription), factory(ManyRelationshipDescription), factory(ListRelationshipDescription), factory(MapRelationshipDescription), Inflector)(ResourceDescription);
   return {
-    get default() {
-      return $__default;
+    get describeResource() {
+      return describeResource;
+    },
+    get InitializedResourceClasses() {
+      return InitializedResourceClasses;
+    },
+    get ResourceDescription() {
+      return ResourceDescription;
     },
     __esModule: true
   };
 });
 
-define('relayer/Transport',["./SimpleFactoryInjector"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var SimpleFactory = $__0.SimpleFactory;
+define('relayer/Transport',[], function() {
+  
   var Transport = function Transport(urlHelper, $http) {
     this.http = $http;
     this.urlHelper = urlHelper;
@@ -4507,11 +4724,11 @@ define('relayer/Transport',["./SimpleFactoryInjector"], function($__0) {
       }));
     },
     resolve: function(backendResponds) {
-      var $__2 = this;
+      var $__0 = this;
       return backendResponds.then((function(fullResponse) {
         if (fullResponse.status === 201 && fullResponse.headers().location) {
-          var locationUrl = $__2.absolutizeResponseLocation(fullResponse);
-          return $__2.get(locationUrl);
+          var locationUrl = $__0.absolutizeResponseLocation(fullResponse);
+          return $__0.get(locationUrl);
         } else {
           var response = {};
           response.data = fullResponse.data;
@@ -4527,9 +4744,6 @@ define('relayer/Transport',["./SimpleFactoryInjector"], function($__0) {
     }
   }, {});
   var $__default = Transport;
-  Object.defineProperty(Transport, "annotations", {get: function() {
-      return [new SimpleFactory('TransportFactory', [])];
-    }});
   return {
     get default() {
       return $__default;
@@ -4538,11 +4752,8 @@ define('relayer/Transport',["./SimpleFactoryInjector"], function($__0) {
   };
 });
 
-define('relayer/UrlHelper',["./SimpleFactoryInjector"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var SimpleFactory = $__0.SimpleFactory;
+define('relayer/UrlHelper',[], function() {
+  
   var UrlHelper = function UrlHelper(baseUrl) {
     if (this.isFullUrl(baseUrl)) {
       baseUrl = this.fullUrlRegEx.exec(baseUrl)[1];
@@ -4582,9 +4793,6 @@ define('relayer/UrlHelper',["./SimpleFactoryInjector"], function($__0) {
     }
   }, {});
   var $__default = UrlHelper;
-  Object.defineProperty(UrlHelper, "annotations", {get: function() {
-      return [new SimpleFactory('UrlHelperFactory', [])];
-    }});
   return {
     get default() {
       return $__default;
@@ -4594,7 +4802,7 @@ define('relayer/UrlHelper',["./SimpleFactoryInjector"], function($__0) {
 });
 
 define('xing-promise',["a1atscript"], function($__0) {
-
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   var $__1 = $__0,
@@ -4646,183 +4854,58 @@ define('xing-promise',["a1atscript"], function($__0) {
   };
 });
 
-define('relayer/RelationshipUtilities',["a1atscript", "./TemplatedUrl"], function($__0,$__2) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  if (!$__2 || !$__2.__esModule)
-    $__2 = {default: $__2};
-  var Service = $__0.Service;
-  var TemplatedUrl = $__2.TemplatedUrl;
-  var RelationshipUtilities = function RelationshipUtilities() {
-    ;
-  };
-  ($traceurRuntime.createClass)(RelationshipUtilities, {addMethods: function(target, resource, name) {
-      target.get = function() {
-        return resource.relationships[name];
-      };
-      target.present = function() {
-        return resource.relationships[name] ? true : false;
-      };
-      target.set = function(newRelationship) {
-        var linksPath = resource.constructor.relationships[name].linksPath;
-        if (resource.relationships[name] instanceof TemplatedUrl) {
-          resource.relationships[name].removeDataPathLink(resource, linksPath);
-          if (!newRelationship) {
-            resource.pathSet(linksPath, "");
-          }
-        }
-        if (newRelationship instanceof TemplatedUrl) {
-          newRelationship.addDataPathLink(resource, linksPath, false);
-        }
-        resource.relationships[name] = newRelationship;
-        if (!resource.relationships[name]) {
-          delete resource.relationships[name];
-        }
-      };
-    }}, {});
-  var $__default = RelationshipUtilities;
-  Object.defineProperty(RelationshipUtilities, "annotations", {get: function() {
-      return [new Service('RelationshipUtilities')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('xing-inflector',["a1atscript"], function($__0) {
-
-  if (!$__0 || !$__0.__esModule)
-    $__0 = {default: $__0};
-  var $__1 = $__0,
-      AsModule = $__1.AsModule,
-      Service = $__1.Service;
-  var Inflector = function Inflector() {
-    ;
-  };
-  ($traceurRuntime.createClass)(Inflector, {
-    camelize: function(key) {
-      if (!angular.isString(key)) {
-        return key;
-      }
-      return key.replace(/_[\w\d]/g, function(match, index, string) {
-        return index === 0 ? match : string.charAt(index + 1).toUpperCase();
-      });
-    },
-    humanize: function(key) {
-      if (!angular.isString(key)) {
-        return key;
-      }
-      return key.replace(/_/g, ' ').replace(/(\w+)/g, function(match) {
-        return match.charAt(0).toUpperCase() + match.slice(1);
-      });
-    },
-    underscore: function(key) {
-      if (!angular.isString(key)) {
-        return key;
-      }
-      return key.replace(/[A-Z]/g, function(match, index) {
-        return index === 0 ? match : '_' + match.toLowerCase();
-      });
-    },
-    dasherize: function(key) {
-      if (!angular.isString(key)) {
-        return key;
-      }
-      return key.replace(/[A-Z]/g, function(match, index) {
-        return index === 0 ? match : '-' + match.toLowerCase();
-      });
-    },
-    pluralize: function(value) {
-      return value + 's';
-    }
-  }, {});
-  var $__default = Inflector;
-  Object.defineProperty(Inflector, "annotations", {get: function() {
-      return [new AsModule('inflector'), new Service('Inflector')];
-    }});
-  return {
-    get default() {
-      return $__default;
-    },
-    __esModule: true
-  };
-});
-
-define('relayer',["./relayer/ResourceDescription", "./relayer/Resource", "./relayer/endpoints", "./relayer/serializers", "./relayer/mappers", "./relayer/transformers", "./relayer/initializers", "./relayer/decorators", "./relayer/relationshipDescriptions", "./relayer/ListResource", "./relayer/PrimaryResourceBuilder", "./relayer/ResourceBuilder", "./relayer/Transport", "./relayer/UrlHelper", "./relayer/TemplatedUrl", "xing-promise", "./relayer/RelationshipUtilities", "a1atscript", "xing-inflector"], function($__0,$__2,$__4,$__5,$__6,$__7,$__8,$__9,$__10,$__11,$__13,$__15,$__17,$__19,$__21,$__22,$__24,$__26,$__28) {
-
+define('relayer',["./relayer/ResourceDescription", "./relayer/Resource", "./relayer/ListResource", "./relayer/Transport", "./relayer/UrlHelper", "./relayer/transformers/PrimaryResourceTransformer", "./relayer/relationshipDescriptions/SingleRelationshipDescription", "./relayer/endpoints/ResolvedEndpoint", "./relayer/TemplatedUrl", "a1atscript", "xing-promise", "./relayer/injector"], function($__0,$__2,$__4,$__6,$__8,$__10,$__12,$__14,$__16,$__18,$__20,$__22) {
+  
   if (!$__0 || !$__0.__esModule)
     $__0 = {default: $__0};
   if (!$__2 || !$__2.__esModule)
     $__2 = {default: $__2};
   if (!$__4 || !$__4.__esModule)
     $__4 = {default: $__4};
-  if (!$__5 || !$__5.__esModule)
-    $__5 = {default: $__5};
   if (!$__6 || !$__6.__esModule)
     $__6 = {default: $__6};
-  if (!$__7 || !$__7.__esModule)
-    $__7 = {default: $__7};
   if (!$__8 || !$__8.__esModule)
     $__8 = {default: $__8};
-  if (!$__9 || !$__9.__esModule)
-    $__9 = {default: $__9};
   if (!$__10 || !$__10.__esModule)
     $__10 = {default: $__10};
-  if (!$__11 || !$__11.__esModule)
-    $__11 = {default: $__11};
-  if (!$__13 || !$__13.__esModule)
-    $__13 = {default: $__13};
-  if (!$__15 || !$__15.__esModule)
-    $__15 = {default: $__15};
-  if (!$__17 || !$__17.__esModule)
-    $__17 = {default: $__17};
-  if (!$__19 || !$__19.__esModule)
-    $__19 = {default: $__19};
-  if (!$__21 || !$__21.__esModule)
-    $__21 = {default: $__21};
+  if (!$__12 || !$__12.__esModule)
+    $__12 = {default: $__12};
+  if (!$__14 || !$__14.__esModule)
+    $__14 = {default: $__14};
+  if (!$__16 || !$__16.__esModule)
+    $__16 = {default: $__16};
+  if (!$__18 || !$__18.__esModule)
+    $__18 = {default: $__18};
+  if (!$__20 || !$__20.__esModule)
+    $__20 = {default: $__20};
   if (!$__22 || !$__22.__esModule)
     $__22 = {default: $__22};
-  if (!$__24 || !$__24.__esModule)
-    $__24 = {default: $__24};
-  if (!$__26 || !$__26.__esModule)
-    $__26 = {default: $__26};
-  if (!$__28 || !$__28.__esModule)
-    $__28 = {default: $__28};
   var $__1 = $__0,
       describeResource = $__1.describeResource,
-      InitializedResourceClasses = $__1.InitializedResourceClasses,
-      ResourceDescription = $__1.ResourceDescription;
+      InitializedResourceClasses = $__1.InitializedResourceClasses;
   var Resource = $__2.default;
-  var Endpoints = $__4;
-  var Serializers = $__5;
-  var Mappers = $__6;
-  var Transformers = $__7;
-  var Initializers = $__8;
-  var Decorators = $__9;
-  var RelationshipDescriptions = $__10;
-  var ListResource = $__11.default;
-  var PrimaryResourceBuilder = $__13.default;
-  var ResourceBuilder = $__15.default;
-  var Transport = $__17.default;
-  var UrlHelper = $__19.default;
-  var TemplatedUrls = $__21;
-  var XingPromise = $__22.default;
-  var RelationshipUtilities = $__24.default;
-  var $__27 = $__26,
-      AsModule = $__27.AsModule,
-      Provider = $__27.Provider;
-  var Inflector = $__28.default;
+  var ListResource = $__4.default;
+  var Transport = $__6.default;
+  var UrlHelper = $__8.default;
+  var PrimaryResourceTransformer = $__10.default;
+  var SingleRelationshipDescription = $__12.default;
+  var ResolvedEndpoint = $__14.default;
+  var TemplatedUrlFromUrl = $__16.TemplatedUrlFromUrl;
+  var $__19 = $__18,
+      AsModule = $__19.AsModule,
+      Provider = $__19.Provider;
+  var XingPromiseFactory = $__20.default;
+  var $__23 = $__22,
+      injector = $__23.default,
+      instance = $__23.instance;
   var ResourceLayer = function ResourceLayer($provide) {
-    var $__30 = this;
+    var $__24 = this;
+    injector.reset();
     this.apis = {};
     this.$provide = $provide;
     this.$get = ['$injector', (function($injector) {
       var builtApis = {};
-      Object.keys($__30.apis).forEach((function(apiName) {
+      Object.keys($__24.apis).forEach((function(apiName) {
         buildApis[apiName] = $injector.get(apiName);
       }));
       return buildApis;
@@ -4833,15 +4916,12 @@ define('relayer',["./relayer/ResourceDescription", "./relayer/Resource", "./rela
         topLevelResource: topLevelResource,
         baseUrl: baseUrl
       };
-      this.$provide.factory(apiName, ['UrlHelperFactory', 'TransportFactory', 'TemplatedUrlFromUrlFactory', 'ResolvedEndpointFactory', 'PrimaryResourceTransformerFactory', 'SingleRelationshipDescriptionFactory', '$http', 'InitializedResourceClasses', function(urlHelperFactory, transportFactory, templatedUrlFromUrlFactory, resolvedEndpointFactory, primaryResourceTransformerFactory, singleRelationshipDescriptionFactory, $http, initializedResourceClasses) {
-        var urlHelper = urlHelperFactory(baseUrl);
-        var wellKnownUrl = urlHelper.fullUrlRegEx.exec(baseUrl)[3];
-        var transport = transportFactory(urlHelper, $http);
-        var templatedUrl = templatedUrlFromUrlFactory(wellKnownUrl, wellKnownUrl);
-        var transformer = primaryResourceTransformerFactory(singleRelationshipDescriptionFactory("", topLevelResource));
-        var endpoint = resolvedEndpointFactory(transport, templatedUrl, transformer);
-        topLevelResource.resourceDescription.applyToEndpoint(endpoint);
-        return endpoint;
+      this.$provide.factory(apiName, ['$http', '$q', function($http, $q) {
+        var XingPromise = XingPromiseFactory.factory($q);
+        injector.XingPromise.value = XingPromise;
+        injector.instantiate(InitializedResourceClasses);
+        var apiBuilder = new APIBuilder($http, topLevelResource, baseUrl);
+        return apiBuilder.build();
       }]);
     }}, {
     get Resource() {
@@ -4856,8 +4936,28 @@ define('relayer',["./relayer/ResourceDescription", "./relayer/Resource", "./rela
   });
   var $__default = ResourceLayer;
   Object.defineProperty(ResourceLayer, "annotations", {get: function() {
-      return [new AsModule('relayer', [Endpoints, Serializers, Mappers, Transformers, Initializers, Decorators, RelationshipDescriptions, ListResource, PrimaryResourceBuilder, ResourceBuilder, Transport, UrlHelper, TemplatedUrls, ResourceDescription, InitializedResourceClasses, ResourceBuilder, PrimaryResourceBuilder, Inflector, XingPromise, RelationshipUtilities]), new Provider('relayer', ['$provide'])];
+      return [new AsModule('relayer', []), new Provider('relayer', ['$provide'])];
     }});
+  var APIBuilder = function APIBuilder($http, topLevelResource, baseUrl) {
+    this.$http = $http;
+    this.topLevelResource = topLevelResource;
+    this.baseUrl = baseUrl;
+  };
+  ($traceurRuntime.createClass)(APIBuilder, {build: function() {
+      var $__26 = this,
+          $http = $__26.$http,
+          topLevelResource = $__26.topLevelResource,
+          baseUrl = $__26.baseUrl;
+      var urlHelper = injector.instantiate(instance(UrlHelper), baseUrl);
+      var wellKnownUrl = urlHelper.fullUrlRegEx.exec(baseUrl)[3];
+      var transport = injector.instantiate(instance(Transport), urlHelper, $http);
+      var templatedUrl = injector.instantiate(instance(TemplatedUrlFromUrl), wellKnownUrl, wellKnownUrl);
+      var relationshipDescription = injector.instantiate(instance(SingleRelationshipDescription), "", topLevelResource);
+      var transformer = injector.instantiate(instance(PrimaryResourceTransformer), relationshipDescription);
+      var endpoint = injector.instantiate(instance(ResolvedEndpoint), transport, templatedUrl, transformer);
+      topLevelResource.resourceDescription.applyToEndpoint(endpoint);
+      return endpoint;
+    }}, {});
   return {
     get default() {
       return $__default;
@@ -4865,3 +4965,4 @@ define('relayer',["./relayer/ResourceDescription", "./relayer/Resource", "./rela
     __esModule: true
   };
 });
+

--- a/dist/relayer/TemporaryTemplatedUrl.js
+++ b/dist/relayer/TemporaryTemplatedUrl.js
@@ -1,0 +1,22 @@
+import {TemplatedUrl} from "./TemplatedUrl.js";
+
+export default class TemporaryTemplatedUrl extends TemplatedUrl {
+
+  static get index() {
+    this._index = this._index || 1;
+    return this._index;
+  }
+
+  static set index(index) {
+    this._index = index;
+    return this._index;
+  }
+
+  constructor(uriTemplate) {
+    super(uriTemplate);
+    var url = this._uriTemplate.fill((varName) => `relayer-${TemporaryTemplatedUrl.index}`);
+    TemporaryTemplatedUrl.index += 1;
+    this._setUrl(url);
+  }
+
+}

--- a/src/relayer/TemporaryTemplatedUrl.js
+++ b/src/relayer/TemporaryTemplatedUrl.js
@@ -1,0 +1,22 @@
+import {TemplatedUrl} from "./TemplatedUrl.js";
+
+export default class TemporaryTemplatedUrl extends TemplatedUrl {
+
+  static get index() {
+    this._index = this._index || 1;
+    return this._index;
+  }
+
+  static set index(index) {
+    this._index = index;
+    return this._index;
+  }
+
+  constructor(uriTemplate) {
+    super(uriTemplate);
+    var url = this._uriTemplate.fill((varName) => `relayer-${TemporaryTemplatedUrl.index}`);
+    TemporaryTemplatedUrl.index += 1;
+    this._setUrl(url);
+  }
+
+}

--- a/test/TemporaryTemplatedUrl.js
+++ b/test/TemporaryTemplatedUrl.js
@@ -1,0 +1,20 @@
+import TemporaryTemplatedUrl from "../src/relayer/TemporaryTemplatedUrl.js"
+
+describe("TemporaryTemplatedUrl", function() {
+  var uriTemplate, templatedUrl1, templatedUrl2;
+
+  beforeEach(function() {
+    uriTemplate = "/books/{abc}/test/{def}";
+    templatedUrl1 = new TemporaryTemplatedUrl(uriTemplate);
+    templatedUrl2 = new TemporaryTemplatedUrl(uriTemplate);
+  });
+
+  it("should create two temporary templated urls that match the template", function() {
+    expect(templatedUrl1.url).toMatch(/\/books\/.*\/test\/.*/);
+    expect(templatedUrl2.url).toMatch(/\/books\/.*\/test\/.*/);
+  });
+
+  it("the templated urls should be unique", function() {
+    expect(templatedUrl1.url).not.toEqual(templatedUrl2.url);
+  });
+});

--- a/test/integration/EmbeddedListCreateTest.js
+++ b/test/integration/EmbeddedListCreateTest.js
@@ -107,26 +107,37 @@ describe("Embedded List Create test", function() {
   });
 
   describe("book", function() {
-    var promise;
+    var books;
 
     beforeEach(function(done) {
-      promise = resources.books().load().then((books) => {
-        book = books.new();
-        return books.create(book)
-      });
-      promise.then((_book_) => {
-        book = _book_;
+      resources.books().load().then((booksLoaded) => {
+        books = booksLoaded;
         done();
       });
       $rootScope.$apply();
     });
 
-    it("should resolve the book", function() {
-      expect(book.title).toEqual("Hamlet");
-    });
-
-    it("should resolve short link", function() {
-      expect(book.shortLink).toEqual("1");
+    it("new with url", function() {
+      expect(books.new(true).url).toMatch(/\/books\/.+/);
     })
+
+    describe("creating", function() {
+      beforeEach(function(done) {
+        book = books.new();
+        books.create(book).then((_book_) => {
+          book = _book_;
+          done();
+        });
+        $rootScope.$evalAsync();
+      });
+
+      it("should resolve the book", function() {
+        expect(book.title).toEqual("Hamlet");
+      });
+
+      it("should resolve short link", function() {
+        expect(book.shortLink).toEqual("1");
+      });
+    });
   });
 });

--- a/test/mappers/ListResourceMapper.js
+++ b/test/mappers/ListResourceMapper.js
@@ -11,6 +11,7 @@ describe("ListResourceMapper", function() {
   ItemResourceClass,
   listResourceMapper,
   templatedUrlFromUrlFactory,
+  temporaryTemplatedUrlFactory,
   templatedUrl,
   templatedUrlDataPathSpy,
   resourceBuilderFactory,
@@ -124,6 +125,10 @@ describe("ListResourceMapper", function() {
       }
     });
 
+    temporaryTemplatedUrlFactory = jasmine.createSpy("temporaryTemplatedUrlFactory").and.returnValue({
+      url: "a url"
+    });
+
     transport = {};
 
     listResourceMapperFactory = function() {
@@ -147,6 +152,7 @@ describe("ListResourceMapper", function() {
       primaryResourceBuilderFactory,
       primaryResourceTransformerFactory,
       manyResourceMapperFactory,
+      temporaryTemplatedUrlFactory,
       transport,
       data,
       relationship);
@@ -195,6 +201,7 @@ describe("ListResourceMapper", function() {
 
     it("should setup new", function() {
       expect(results.new().awesome).toEqual("awesome");
+      expect(results.new(true).templatedUrl).toEqual({url: "a url"});
     });
 
     it("should have the right properties", function() {


### PR DESCRIPTION
This PR adds a feature which was implemented in Yoric through a private API which broke when we did the refactor.

Essentially, there are certain cases where it is neccessary to have a temporary URL to help "identify" a resource prior to it's being persisted on the backend. An example of this is for searching purposes, or using shortLinks for CSS ids. This url never transmits to the backend -- it simply serves to help locate the resource when finding in a list, or watching for changes. isPersisted remains false until a backend response is received.
